### PR TITLE
Migrate dependencies too

### DIFF
--- a/src/main/resources/META-INF/rewrite/codehaus-to-fasterxml.yml
+++ b/src/main/resources/META-INF/rewrite/codehaus-to-fasterxml.yml
@@ -33,3 +33,18 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.codehaus.jackson.map.ObjectMapper
       newFullyQualifiedTypeName: com.fasterxml.jackson.databind.ObjectMapper
+
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.codehaus.jackson
+      oldArtifactId: jackson-mapper-asl
+      newGroupId: com.fasterxml.jackson.core
+      newArtifactId: jackson-databind
+      newVersion: 2.x
+      overrideManagedVersion: false
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.codehaus.jackson
+      oldArtifactId: jackson-core-asl
+      newGroupId: com.fasterxml.jackson.core
+      newArtifactId: jackson-core
+      newVersion: 2.x
+      overrideManagedVersion: false

--- a/src/test/java/org/openrewrite/java/jackson/CodehausToFasterXMLTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/CodehausToFasterXMLTest.java
@@ -15,12 +15,17 @@
  */
 package org.openrewrite.java.jackson;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.regex.Pattern;
+
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
 
 class CodehausToFasterXMLTest implements RewriteTest {
 
@@ -31,6 +36,7 @@ class CodehausToFasterXMLTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
     }
 
+    @DocumentExample
     @Test
     void onlyJsonSerializeInclusion() {
         rewriteRun(
@@ -61,5 +67,60 @@ class CodehausToFasterXMLTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Nested
+    class Dependencies {
+        @Test
+        void changeDependencies() {
+            rewriteRun(
+              //language=xml
+              pomXml(
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>my-app</artifactId>
+                      <version>1</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.codehaus.jackson</groupId>
+                              <artifactId>jackson-core-asl</artifactId>
+                              <version>1.9.13</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>org.codehaus.jackson</groupId>
+                              <artifactId>jackson-mapper-asl</artifactId>
+                              <version>1.9.13</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """,
+                after -> after.after(pomXml -> {
+                    String version = Pattern.compile("<version>(2\\.\\d+\\.\\d+)</version>").matcher(pomXml).results().findFirst().get().group(1);
+                    return """
+                      <project>
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>com.mycompany.app</groupId>
+                          <artifactId>my-app</artifactId>
+                          <version>1</version>
+                          <dependencies>
+                              <dependency>
+                                  <groupId>com.fasterxml.jackson.core</groupId>
+                                  <artifactId>jackson-core</artifactId>
+                                  <version>%1$s</version>
+                              </dependency>
+                              <dependency>
+                                  <groupId>com.fasterxml.jackson.core</groupId>
+                                  <artifactId>jackson-databind</artifactId>
+                                  <version>%s</version>
+                              </dependency>
+                          </dependencies>
+                      </project>
+                      """.formatted(version);
+                })
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
## What's changed?
Additional recipes to migrate outdated dependencies to newer equivalents.

## What's your motivation?
Required following package changes.

## Anything in particular you'd like reviewers to focus on?
Only briefly looked at the dependency mapping; think it's ok, but I never used the older dependencies.

## Have you considered any alternatives or workarounds?
This assumes an existing dependency; we could additionally use `AddDependency` + `onlyIfUsing` to ensure there's one of codehaus Jackson came in transitively.