### PR TITLE
Remove doubly annotated codehaus annotations

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
@@ -48,7 +48,7 @@ public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
                 ),
                 new JavaVisitor<ExecutionContext>() {
                     @Override
-                    public J preVisit(@NonNull J tree, ExecutionContext executionContext) {
+                    public J preVisit(@NonNull J tree, ExecutionContext ctx) {
                         stopAfterPreVisit();
                         doAfterVisit(new RemoveAnnotationVisitor(new AnnotationMatcher("@org.codehaus.jackson.map.annotate.JsonSerialize", true)));
                         maybeRemoveImport("org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.*");

--- a/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.jackson.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.jackson.codehaus;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.AnnotationMatcher;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.RemoveAnnotationVisitor;
+import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.J;
+
+public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Remove Codehaus Jackson annotations if doubly annotated";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove Codehaus Jackson annotations if they are doubly annotated with Jackson annotations from the `com.fasterxml.jackson` package.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(
+                Preconditions.or(
+                        new UsesType<>("com.fasterxml.jackson.annotation.JsonInclude", false),
+                        new UsesType<>("com.fasterxml.jackson.databind.annotation.JsonSerialize", false)
+                ),
+                new JavaVisitor<ExecutionContext>() {
+                    @Override
+                    public @Nullable J preVisit(@NonNull J tree, ExecutionContext executionContext) {
+                        stopAfterPreVisit();
+                        doAfterVisit(new RemoveAnnotationVisitor(new AnnotationMatcher("@org.codehaus.jackson.map.annotate.JsonSerialize", true)));
+                        maybeRemoveImport("org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.*");
+                        maybeRemoveImport("org.codehaus.jackson.map.annotate.JsonSerialize.Typing.*");
+                        doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
+                        return tree;
+                    }
+                });
+    }
+}

--- a/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
@@ -16,7 +16,6 @@
 package org.openrewrite.java.jackson.codehaus;
 
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -49,7 +48,7 @@ public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
                 ),
                 new JavaVisitor<ExecutionContext>() {
                     @Override
-                    public @Nullable J preVisit(@NonNull J tree, ExecutionContext executionContext) {
+                    public J preVisit(@NonNull J tree, ExecutionContext executionContext) {
                         stopAfterPreVisit();
                         doAfterVisit(new RemoveAnnotationVisitor(new AnnotationMatcher("@org.codehaus.jackson.map.annotate.JsonSerialize", true)));
                         maybeRemoveImport("org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.*");

--- a/src/main/resources/META-INF/rewrite/codehaus-to-fasterxml.yml
+++ b/src/main/resources/META-INF/rewrite/codehaus-to-fasterxml.yml
@@ -21,6 +21,7 @@ displayName: Migrate from Jackson Codehaus (legacy) to Jackson FasterXML
 description: >-
   In Jackson 2, the package and dependency coordinates moved from Codehaus to FasterXML.
 recipeList:
+  - org.openrewrite.java.jackson.codehaus.RemoveDoublyAnnotatedCodehausAnnotations
   - org.openrewrite.java.jackson.CodehausClassesToFasterXML
   - org.openrewrite.java.jackson.codehaus.CodehausDependencyToFasterXML:
       version: 2.x

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
@@ -22,7 +22,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-class RemoveDuplicateCodehausAnnotationsTest implements RewriteTest {
+class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.jackson.codehaus;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -31,6 +32,7 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
           .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
     }
 
+    @DocumentExample
     @Test
     void removeCodehausAnnotationsIfDoublyAnnotated() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDuplicateCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDuplicateCodehausAnnotationsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.jackson.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.jackson.codehaus;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveDuplicateCodehausAnnotationsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .recipe(new RemoveDoublyAnnotatedCodehausAnnotations())
+          .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+    }
+
+    @Test
+    void removeCodehausAnnotationsIfDoublyAnnotated() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.codehaus.jackson.map.annotate.JsonSerialize;
+              import org.codehaus.jackson.map.JsonSerializer.None;
+              import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
+              
+              @JsonSerialize(include = NON_NULL, using = None.class)
+              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+              class Test {
+              }
+              """,
+            """
+              import com.fasterxml.jackson.databind.JsonSerializer;
+              import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+              
+              @JsonSerialize(using = JsonSerializer.None.class)
+              class Test {
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's changed?
Add a new recipe that merely removes Codehaus Jackson annotations when the repalcement FasterXML Jackson annotations are already present.

## What's your motivation?
We got reports that sometimes both are present, and the migration recipe fails to take that into account.

## Anything in particular you'd like reviewers to focus on?
Are there additional annotations that should similarly be removed?
Are there other classes that should feed into the precondition?
Should the precondition be narrowed to only look for usage as annotation?