### PR TITLE
Only `RemoveDoublyAnnotatedCodehausAnnotations` from the same element; not any element in the same class

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
@@ -25,10 +25,11 @@ import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.J;
 
+import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
+
     private static final AnnotationMatcher MATCHER_FASTERXML = new AnnotationMatcher("@com.fasterxml.jackson.databind.annotation.JsonSerialize", true);
     private static final AnnotationMatcher MATCHER_CODEHAUS = new AnnotationMatcher("@org.codehaus.jackson.map.annotate.JsonSerialize", true);
 
@@ -54,9 +55,7 @@ public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
                     public J preVisit(@NonNull J tree, ExecutionContext ctx) {
                         stopAfterPreVisit();
 
-                        Set<J.Annotation> annotationsToRemove = ConcurrentHashMap.newKeySet();
-                        new FindDoublyAnnotatedVisitor().reduce(tree, annotationsToRemove);
-
+                        Set<J.Annotation> annotationsToRemove = new FindDoublyAnnotatedVisitor().reduce(tree, new HashSet<>());
                         AnnotationMatcher matcher = new AnnotationMatcher("@org.codehaus.jackson.map.annotate.JsonSerialize", true) {
                             @Override
                             public boolean matches(J.Annotation annotation) {

--- a/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
@@ -59,7 +59,7 @@ public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
                         AnnotationMatcher matcher = new AnnotationMatcher("@org.codehaus.jackson.map.annotate.JsonSerialize", true) {
                             @Override
                             public boolean matches(J.Annotation annotation) {
-                                return super.matches(annotation) && annotationsToRemove.contains(annotation);
+                                return annotationsToRemove.contains(annotation);
                             }
                         };
 

--- a/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
@@ -56,7 +56,9 @@ public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
                         stopAfterPreVisit();
 
                         Set<J.Annotation> annotationsToRemove = new FindDoublyAnnotatedVisitor().reduce(tree, new HashSet<>());
-                        AnnotationMatcher matcher = new AnnotationMatcher("@org.codehaus.jackson.map.annotate.JsonSerialize", true) {
+                        AnnotationMatcher matcher = new AnnotationMatcher(
+                                // ignored in practice, as we only match annotations previously found just above
+                                "@org.codehaus.jackson.map.annotate.JsonSerialize", true) {
                             @Override
                             public boolean matches(J.Annotation annotation) {
                                 return annotationsToRemove.contains(annotation);

--- a/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
@@ -46,10 +46,7 @@ public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(
-                Preconditions.or(
-                        new UsesType<>("com.fasterxml.jackson.annotation.JsonInclude", false),
-                        new UsesType<>("com.fasterxml.jackson.databind.annotation.JsonSerialize", false)
-                ),
+                new UsesType<>("com.fasterxml.jackson.databind.annotation.JsonSerialize", false),
                 new JavaVisitor<ExecutionContext>() {
                     @Override
                     public J preVisit(@NonNull J tree, ExecutionContext ctx) {

--- a/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotations.java
@@ -20,14 +20,17 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.java.AnnotationMatcher;
-import org.openrewrite.java.JavaVisitor;
-import org.openrewrite.java.RemoveAnnotationVisitor;
-import org.openrewrite.java.ShortenFullyQualifiedTypeReferences;
+import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.tree.J;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
+    private static final AnnotationMatcher MATCHER_FASTERXML = new AnnotationMatcher("@com.fasterxml.jackson.databind.annotation.JsonSerialize", true);
+    private static final AnnotationMatcher MATCHER_CODEHAUS = new AnnotationMatcher("@org.codehaus.jackson.map.annotate.JsonSerialize", true);
 
     @Override
     public String getDisplayName() {
@@ -50,7 +53,18 @@ public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
                     @Override
                     public J preVisit(@NonNull J tree, ExecutionContext ctx) {
                         stopAfterPreVisit();
-                        doAfterVisit(new RemoveAnnotationVisitor(new AnnotationMatcher("@org.codehaus.jackson.map.annotate.JsonSerialize", true)));
+
+                        Set<J.Annotation> annotationsToRemove = ConcurrentHashMap.newKeySet();
+                        new FindDoublyAnnotatedVisitor().reduce(tree, annotationsToRemove);
+
+                        AnnotationMatcher matcher = new AnnotationMatcher("@org.codehaus.jackson.map.annotate.JsonSerialize", true) {
+                            @Override
+                            public boolean matches(J.Annotation annotation) {
+                                return super.matches(annotation) && annotationsToRemove.contains(annotation);
+                            }
+                        };
+
+                        doAfterVisit(new RemoveAnnotationVisitor(matcher));
                         maybeRemoveImport("org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.*");
                         maybeRemoveImport("org.codehaus.jackson.map.annotate.JsonSerialize.Typing.*");
                         doAfterVisit(new ShortenFullyQualifiedTypeReferences().getVisitor());
@@ -58,4 +72,16 @@ public class RemoveDoublyAnnotatedCodehausAnnotations extends Recipe {
                     }
                 });
     }
+
+    private static class FindDoublyAnnotatedVisitor extends JavaIsoVisitor<Set<J.Annotation>> {
+        @Override
+        public J.Annotation visitAnnotation(J.Annotation annotation, Set<J.Annotation> doublyAnnotated) {
+            J.Annotation a = super.visitAnnotation(annotation, doublyAnnotated);
+            if (MATCHER_CODEHAUS.matches(annotation) && service(AnnotationService.class).matches(getCursor().getParentOrThrow(), MATCHER_FASTERXML)) {
+                doublyAnnotated.add(annotation);
+            }
+            return a;
+        }
+    }
+
 }

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
@@ -61,6 +61,37 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
     }
 
     @Test
+    void removeCodehausAnnotationsDoublyAnnotatedAndRefactorImports() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            import org.codehaus.jackson.map.annotate.JsonSerialize;
+            import org.codehaus.jackson.map.JsonSerializer.None;
+            import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
+            
+            @JsonSerialize(include = NON_NULL, using = None.class)
+            @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+            class Test {
+              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+              private String first;
+            }
+            """, """
+            import com.fasterxml.jackson.databind.JsonSerializer;
+            import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+            
+            @JsonSerialize(using = JsonSerializer.None.class)
+            class Test {
+              @JsonSerialize(using = JsonSerializer.None.class)
+              private String first;
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void preserveCodehausAnnotationsIfNotDoublyAnnotated() {
         rewriteRun(
           //language=java
@@ -70,7 +101,7 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
               import org.codehaus.jackson.map.JsonSerializer.None;
               import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
               
-              @JsonSerialize(using = JsonSerializer.None.class)
+              @JsonSerialize(using = None.class)
               class Test {
                 @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
                 private String first;
@@ -91,7 +122,8 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
             import org.codehaus.jackson.map.JsonSerializer.None;
             import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
             
-            @JsonSerialize(using = JsonSerializer.None.class)
+            @JsonSerialize(include = NON_NULL, using = None.class)
+            @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
             class Test {
               @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
               private String first;
@@ -101,16 +133,16 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
               private String second;
             }
             """, """
+            import com.fasterxml.jackson.databind.JsonSerializer;
             import org.codehaus.jackson.map.annotate.JsonSerialize;
-            import org.codehaus.jackson.map.JsonSerializer.None;
             import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
             
-            @JsonSerialize(using = JsonSerializer.None.class)
+            @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = JsonSerializer.None.class)
             class Test {
               @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
               private String first;
             
-              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = JsonSerializer.None.class)
               private String second;
             }
             """

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
@@ -64,18 +64,19 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
     void preserveCodehausAnnotationsIfNotDoublyAnnotated() {
         rewriteRun(
           //language=java
-          java("""
-            import org.codehaus.jackson.map.annotate.JsonSerialize;
-            import org.codehaus.jackson.map.JsonSerializer.None;
-            import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
-            
-            @JsonSerialize(using = JsonSerializer.None.class)
-            class Test {
-              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
-              private String first;
-            
-            }
+          java(
             """
+              import org.codehaus.jackson.map.annotate.JsonSerialize;
+              import org.codehaus.jackson.map.JsonSerializer.None;
+              import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
+              
+              @JsonSerialize(using = JsonSerializer.None.class)
+              class Test {
+                @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+                private String first;
+              
+              }
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
+@SuppressWarnings("DefaultAnnotationParam")
 class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
 
     @Override
@@ -66,27 +67,28 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
           //language=java
           java(
             """
-            import org.codehaus.jackson.map.annotate.JsonSerialize;
-            import org.codehaus.jackson.map.JsonSerializer.None;
-            import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
-            
-            @JsonSerialize(include = NON_NULL, using = None.class)
-            @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
-            class Test {
-              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+              import org.codehaus.jackson.map.annotate.JsonSerialize;
+              import org.codehaus.jackson.map.JsonSerializer.None;
+              import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
+              
+              @JsonSerialize(include = NON_NULL, using = None.class)
               @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
-              private String first;
-            }
-            """, """
-            import com.fasterxml.jackson.databind.JsonSerializer;
-            import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-            
-            @JsonSerialize(using = JsonSerializer.None.class)
-            class Test {
-              @JsonSerialize(using = JsonSerializer.None.class)
-              private String first;
-            }
+              class Test {
+                @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+                @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+                private String first;
+              }
+              """,
             """
+              import com.fasterxml.jackson.databind.JsonSerializer;
+              import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+              
+              @JsonSerialize(using = JsonSerializer.None.class)
+              class Test {
+                @JsonSerialize(using = JsonSerializer.None.class)
+                private String first;
+              }
+              """
           )
         );
     }
@@ -118,34 +120,35 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
           //language=java
           java(
             """
-            import org.codehaus.jackson.map.annotate.JsonSerialize;
-            import org.codehaus.jackson.map.JsonSerializer.None;
-            import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
-            
-            @JsonSerialize(include = NON_NULL, using = None.class)
-            @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
-            class Test {
-              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
-              private String first;
-            
+              import org.codehaus.jackson.map.annotate.JsonSerialize;
+              import org.codehaus.jackson.map.JsonSerializer.None;
+              import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
+              
               @JsonSerialize(include = NON_NULL, using = None.class)
               @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
-              private String second;
-            }
-            """, """
-            import com.fasterxml.jackson.databind.JsonSerializer;
-            import org.codehaus.jackson.map.annotate.JsonSerialize;
-            import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
-            
-            @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = JsonSerializer.None.class)
-            class Test {
-              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
-              private String first;
-            
-              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = JsonSerializer.None.class)
-              private String second;
-            }
+              class Test {
+                @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+                private String first;
+              
+                @JsonSerialize(include = NON_NULL, using = None.class)
+                @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+                private String second;
+              }
+              """,
             """
+              import com.fasterxml.jackson.databind.JsonSerializer;
+              import org.codehaus.jackson.map.annotate.JsonSerialize;
+              import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
+              
+              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = JsonSerializer.None.class)
+              class Test {
+                @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+                private String first;
+              
+                @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = JsonSerializer.None.class)
+                private String second;
+              }
+              """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
@@ -87,32 +87,33 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
           //language=java
           java(
             """
-              import org.codehaus.jackson.map.annotate.JsonSerialize;
-              import org.codehaus.jackson.map.JsonSerializer.None;
-              import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
-              
-              @JsonSerialize(using = JsonSerializer.None.class)
-              class Test {
-                @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
-                private String first;
-              
-                @JsonSerialize(include = NON_NULL, using = None.class)
-                @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
-                private String second;
-              }
-              """, """
-              import com.fasterxml.jackson.databind.JsonSerializer;
-              import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-              
-              @JsonSerialize(using = JsonSerializer.None.class)
-              class Test {
-                @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
-                private String first;
-              
-                @JsonSerialize(using = JsonSerializer.None.class)
-                private String second;
-              }
-              """
+            import org.codehaus.jackson.map.annotate.JsonSerialize;
+            import org.codehaus.jackson.map.JsonSerializer.None;
+            import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
+            
+            @JsonSerialize(using = JsonSerializer.None.class)
+            class Test {
+              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+              private String first;
+            
+              @JsonSerialize(include = NON_NULL, using = None.class)
+              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+              private String second;
+            }
+            """, """
+            import org.codehaus.jackson.map.annotate.JsonSerialize;
+            import org.codehaus.jackson.map.JsonSerializer.None;
+            import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
+            
+            @JsonSerialize(using = JsonSerializer.None.class)
+            class Test {
+              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+              private String first;
+            
+              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+              private String second;
+            }
+            """
           )
         );
     }

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
@@ -59,4 +59,55 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void preserveCodehausAnnotationsIfNotDoublyAnnotated() {
+        rewriteRun(
+          //language=java
+          java("""
+            import org.codehaus.jackson.map.annotate.JsonSerialize;
+            import org.codehaus.jackson.map.JsonSerializer.None;
+            import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
+            
+            @JsonSerialize(using = JsonSerializer.None.class)
+            class Test {
+              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+              private String first;
+           
+            }"""));
+    }
+
+    @Test
+    void preserveCodehausAnnotationsIfNotDoublyAnnotatedCombined() {
+        rewriteRun(
+          //language=java
+          java("""
+            import org.codehaus.jackson.map.annotate.JsonSerialize;
+            import org.codehaus.jackson.map.JsonSerializer.None;
+            import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
+            
+            @JsonSerialize(using = JsonSerializer.None.class)
+            class Test {
+              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+              private String first;
+            
+              @JsonSerialize(include = NON_NULL, using = None.class)
+              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+              private String second;
+            }
+            """, """
+            import com.fasterxml.jackson.databind.JsonSerializer;
+            import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+            
+            @JsonSerialize(using = JsonSerializer.None.class)
+            class Test {
+              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+              private String first;
+              
+              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+              private String second;
+            }
+            """));
+    }
+
 }

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
@@ -73,8 +73,11 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
             class Test {
               @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
               private String first;
-           
-            }"""));
+            
+            }
+            """
+          )
+        );
     }
 
     @Test
@@ -82,33 +85,34 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
         rewriteRun(
           //language=java
           java(
-                """
-            import org.codehaus.jackson.map.annotate.JsonSerialize;
-            import org.codehaus.jackson.map.JsonSerializer.None;
-            import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
-            
-            @JsonSerialize(using = JsonSerializer.None.class)
-            class Test {
-              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
-              private String first;
-            
-              @JsonSerialize(include = NON_NULL, using = None.class)
-              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
-              private String second;
-            }
-            """, """
-            import com.fasterxml.jackson.databind.JsonSerializer;
-            import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-            
-            @JsonSerialize(using = JsonSerializer.None.class)
-            class Test {
-              @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
-              private String first;
+            """
+              import org.codehaus.jackson.map.annotate.JsonSerialize;
+              import org.codehaus.jackson.map.JsonSerializer.None;
+              import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;
               
-              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
-              private String second;
-            }
-            """));
+              @JsonSerialize(using = JsonSerializer.None.class)
+              class Test {
+                @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+                private String first;
+              
+                @JsonSerialize(include = NON_NULL, using = None.class)
+                @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.fasterxml.jackson.databind.JsonSerializer.None.class)
+                private String second;
+              }
+              """, """
+              import com.fasterxml.jackson.databind.JsonSerializer;
+              import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+              
+              @JsonSerialize(using = JsonSerializer.None.class)
+              class Test {
+                @JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
+                private String first;
+              
+                @JsonSerialize(using = JsonSerializer.None.class)
+                private String second;
+              }
+              """
+          )
+        );
     }
-
 }

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
@@ -81,7 +81,8 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
     void preserveCodehausAnnotationsIfNotDoublyAnnotatedCombined() {
         rewriteRun(
           //language=java
-          java("""
+          java(
+                """
             import org.codehaus.jackson.map.annotate.JsonSerialize;
             import org.codehaus.jackson.map.JsonSerializer.None;
             import static org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion.NON_NULL;

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/RemoveDoublyAnnotatedCodehausAnnotationsTest.java
@@ -152,4 +152,26 @@ class RemoveDoublyAnnotatedCodehausAnnotationsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void retainInPresenceOfV2JsonInclude() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.codehaus.jackson.map.annotate.JsonSerialize;
+              import org.codehaus.jackson.map.ser.BeanSerializer;
+              import com.fasterxml.jackson.annotation.JsonInclude;
+              import com.fasterxml.jackson.databind.JsonSerializer;
+              
+              @com.fasterxml.jackson.databind.annotation.JsonSerialize(using = JsonSerializer.None.class)
+              class Test {
+                  @JsonSerialize(using = BeanSerializer.class)
+                  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+                  private String sixth;
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
The recipe `RemoveDoublyAnnotatedCodehausAnnotations` should remove the `codehaus` annotation if a `fasterxml` annotation is already present on the element. However, the current recipe will remove all `codehause` annotations when a single element has been annotated doubly. This PR will ensure that the `codehaus` annotations are only removed from elements that also contain a `fasterxml` annotation and add test cases.

## What's your motivation?
It illustrates a situation that causes annotation to be removed erroneously. 

## Anyone you would like to review specifically?
@timtebeek @laurens-w

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
