### PR TITLE
Replace Codehaus `setAnnotationIntrospector` with FasterXML equivalent

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,9 +17,12 @@ dependencies {
         exclude("com.google.auto.service", "auto-service-annotations")
     }
 
+    testImplementation("com.fasterxml.jackson.core:jackson-core:latest.release")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:latest.release")
+    testImplementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:latest.release")
     testImplementation("org.codehaus.jackson:jackson-core-asl:latest.release")
     testImplementation("org.codehaus.jackson:jackson-mapper-asl:latest.release")
+    testImplementation("org.codehaus.jackson:jackson-xc:latest.release")
 
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-test")
@@ -30,4 +33,8 @@ dependencies {
 
 recipeDependencies {
     parserClasspath("com.fasterxml.jackson.core:jackson-annotations:latest.release")
+    parserClasspath("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:latest.release")
+    parserClasspath("org.codehaus.jackson:jackson-core-asl:latest.release")
+    parserClasspath("org.codehaus.jackson:jackson-mapper-asl:latest.release")
+    parserClasspath("org.codehaus.jackson:jackson-xc:latest.release")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     testImplementation("com.fasterxml.jackson.core:jackson-databind:latest.release")
     testImplementation("org.codehaus.jackson:jackson-core-asl:latest.release")
     testImplementation("org.codehaus.jackson:jackson-mapper-asl:latest.release")
+    testImplementation("org.codehaus.jackson:jackson-xc:latest.release")
 
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,12 +17,9 @@ dependencies {
         exclude("com.google.auto.service", "auto-service-annotations")
     }
 
-    testImplementation("com.fasterxml.jackson.core:jackson-core:latest.release")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:latest.release")
-    testImplementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:latest.release")
     testImplementation("org.codehaus.jackson:jackson-core-asl:latest.release")
     testImplementation("org.codehaus.jackson:jackson-mapper-asl:latest.release")
-    testImplementation("org.codehaus.jackson:jackson-xc:latest.release")
 
     testImplementation("org.openrewrite:rewrite-java-17")
     testImplementation("org.openrewrite:rewrite-test")
@@ -33,8 +30,4 @@ dependencies {
 
 recipeDependencies {
     parserClasspath("com.fasterxml.jackson.core:jackson-annotations:latest.release")
-    parserClasspath("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:latest.release")
-    parserClasspath("org.codehaus.jackson:jackson-core-asl:latest.release")
-    parserClasspath("org.codehaus.jackson:jackson-mapper-asl:latest.release")
-    parserClasspath("org.codehaus.jackson:jackson-xc:latest.release")
 }

--- a/src/main/java/org/openrewrite/java/jackson/codehaus/ReplaceSerializationConfigAnnotationIntrospector.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/ReplaceSerializationConfigAnnotationIntrospector.java
@@ -23,7 +23,6 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.search.UsesMethod;
-import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor;
 import org.openrewrite.java.tree.J;
 
@@ -68,7 +67,6 @@ public class ReplaceSerializationConfigAnnotationIntrospector extends Recipe {
         };
         return Preconditions.check(
                 Preconditions.and(
-                        new UsesType<>("org.codehaus.jackson.map.ObjectMapper", true),
                         new UsesMethod<>("org.codehaus.jackson.map.MapperConfig setAnnotationIntrospector(..)", true),
                         new UsesMethod<>("org.codehaus.jackson.map.ObjectMapper getSerializationConfig(..)", true)
                 ),

--- a/src/main/java/org/openrewrite/java/jackson/codehaus/ReplaceSerializationConfigAnnotationIntrospector.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/ReplaceSerializationConfigAnnotationIntrospector.java
@@ -41,6 +41,7 @@ public class ReplaceSerializationConfigAnnotationIntrospector extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
+        // The before and after templates use different types matching types, so we use JavaTemplate.Matcher here only
         JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
             final JavaTemplate before = JavaTemplate
                     .builder("#{mapper:any(org.codehaus.jackson.map.ObjectMapper)}.getSerializationConfig().setAnnotationIntrospector(#{introspector:any(org.codehaus.jackson.map.AnnotationIntrospector)});")
@@ -67,8 +68,8 @@ public class ReplaceSerializationConfigAnnotationIntrospector extends Recipe {
         };
         return Preconditions.check(
                 Preconditions.and(
-                        new UsesMethod<>("org.codehaus.jackson.map.MapperConfig setAnnotationIntrospector(..)", true),
-                        new UsesMethod<>("org.codehaus.jackson.map.ObjectMapper getSerializationConfig(..)", true)
+                        new UsesMethod<>("org.codehaus.jackson.map.ObjectMapper getSerializationConfig(..)", true),
+                        new UsesMethod<>("org.codehaus.jackson.map.MapperConfig setAnnotationIntrospector(..)", true)
                 ),
                 javaVisitor
         );

--- a/src/main/java/org/openrewrite/java/jackson/codehaus/ReplaceSerializationConfigAnnotationIntrospector.java
+++ b/src/main/java/org/openrewrite/java/jackson/codehaus/ReplaceSerializationConfigAnnotationIntrospector.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.jackson.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.jackson.codehaus;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.search.UsesMethod;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor;
+import org.openrewrite.java.tree.J;
+
+import static org.openrewrite.java.template.internal.AbstractRefasterJavaVisitor.EmbeddingOption.SHORTEN_NAMES;
+
+public class ReplaceSerializationConfigAnnotationIntrospector extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Migrate serialization annotation processor";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate serialization annotation processor to use the codehaus config method.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        JavaVisitor<ExecutionContext> javaVisitor = new AbstractRefasterJavaVisitor() {
+            final JavaTemplate before = JavaTemplate
+                    .builder("#{mapper:any(org.codehaus.jackson.map.ObjectMapper)}.getSerializationConfig().setAnnotationIntrospector(#{introspector:any(org.codehaus.jackson.map.AnnotationIntrospector)});")
+                    .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                    .build();
+            final JavaTemplate after = JavaTemplate
+                    .builder("#{mapper:any(com.fasterxml.jackson.databind.ObjectMapper)}.setConfig(#{mapper}.getSerializationConfig().with(#{introspector:any(com.fasterxml.jackson.databind.AnnotationIntrospector)}));")
+                    .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
+                    .build();
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation elem, ExecutionContext ctx) {
+                JavaTemplate.Matcher matcher = before.matcher(getCursor());
+                if (matcher.find()) {
+                    return embed(
+                            after.apply(getCursor(), elem.getCoordinates().replace(), matcher.parameter(0), matcher.parameter(1)),
+                            getCursor(),
+                            ctx,
+                            SHORTEN_NAMES
+                    );
+                }
+                return super.visitMethodInvocation(elem, ctx);
+            }
+        };
+        return Preconditions.check(
+                Preconditions.and(
+                        new UsesType<>("org.codehaus.jackson.map.ObjectMapper", true),
+                        new UsesMethod<>("org.codehaus.jackson.map.MapperConfig setAnnotationIntrospector(..)", true),
+                        new UsesMethod<>("org.codehaus.jackson.map.ObjectMapper getSerializationConfig(..)", true)
+                ),
+                javaVisitor
+        );
+    }
+
+}

--- a/src/main/resources/META-INF/rewrite/codehaus-to-fasterxml.yml
+++ b/src/main/resources/META-INF/rewrite/codehaus-to-fasterxml.yml
@@ -35,6 +35,7 @@ description: >-
   In Jackson 2, the package and dependency coordinates moved from Codehaus to FasterXML.
 recipeList:
   - org.openrewrite.java.jackson.codehaus.JsonIncludeAnnotation
+  - org.openrewrite.java.jackson.codehaus.ReplaceSerializationConfigAnnotationIntrospector
 
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.codehaus.jackson.map.JsonSerializer
@@ -45,6 +46,12 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.codehaus.jackson.map.annotate.JsonSerialize
       newFullyQualifiedTypeName: com.fasterxml.jackson.databind.annotation.JsonSerialize
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.codehaus.jackson.map.AnnotationIntrospector
+      newFullyQualifiedTypeName: com.fasterxml.jackson.databind.AnnotationIntrospector
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.codehaus.jackson.xc.JaxbAnnotationIntrospector
+      newFullyQualifiedTypeName: com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.codehaus.jackson.map.ObjectMapper
       newFullyQualifiedTypeName: com.fasterxml.jackson.databind.ObjectMapper

--- a/src/main/resources/META-INF/rewrite/codehaus-to-fasterxml.yml
+++ b/src/main/resources/META-INF/rewrite/codehaus-to-fasterxml.yml
@@ -53,6 +53,15 @@ recipeList:
       oldFullyQualifiedTypeName: org.codehaus.jackson.xc.JaxbAnnotationIntrospector
       newFullyQualifiedTypeName: com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector
   - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector
+      newFullyQualifiedTypeName: com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.codehaus.jackson.map.AnnotationIntrospector.Pair
+      newFullyQualifiedTypeName: com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.codehaus.jackson.map.introspect.NopAnnotationIntrospector
+      newFullyQualifiedTypeName: com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
+  - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.codehaus.jackson.map.ObjectMapper
       newFullyQualifiedTypeName: com.fasterxml.jackson.databind.ObjectMapper
 

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/CodehausToFasterXMLTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/CodehausToFasterXMLTest.java
@@ -76,7 +76,7 @@ class CodehausToFasterXMLTest implements RewriteTest {
               import org.codehaus.jackson.map.ObjectMapper;
 
               import static org.codehaus.jackson.map.SerializationConfig.Feature.WRAP_ROOT_VALUE;
-              
+
               class Test {
                   void foo(){
                       ObjectMapper mapper = new ObjectMapper();
@@ -325,6 +325,64 @@ class CodehausToFasterXMLTest implements RewriteTest {
               class Test {
                   @JsonInclude(value = JsonInclude.Include.NON_NULL)
                   void method() {}
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceWithSetConfigCallGeneric() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.codehaus.jackson.map.AnnotationIntrospector;
+              import org.codehaus.jackson.map.ObjectMapper;
+
+              class Test {
+                  void method(ObjectMapper mapper, AnnotationIntrospector introspector) {
+                      mapper.getSerializationConfig().setAnnotationIntrospector(introspector);
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.databind.AnnotationIntrospector;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void method(ObjectMapper mapper, AnnotationIntrospector introspector) {
+                      mapper.setConfig(mapper.getSerializationConfig().with(introspector));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceWithSetConfigCallJaxB() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.codehaus.jackson.map.ObjectMapper;
+              import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
+
+              class Test {
+                  void method(ObjectMapper mapper, JaxbAnnotationIntrospector introspector) {
+                      mapper.getSerializationConfig().setAnnotationIntrospector(introspector);
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+
+              class Test {
+                  void method(ObjectMapper mapper, JaxbAnnotationIntrospector introspector) {
+                      mapper.setConfig(mapper.getSerializationConfig().with(introspector));
+                  }
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/CodehausToFasterXMLTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/CodehausToFasterXMLTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.jackson.codehaus;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -331,6 +332,7 @@ class CodehausToFasterXMLTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-jackson/issues/17")
     @Test
     void replaceWithSetConfigCallGeneric() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/CodehausToFasterXMLTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/CodehausToFasterXMLTest.java
@@ -333,6 +333,7 @@ class CodehausToFasterXMLTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite-jackson/issues/17")
+    @Issue("https://github.com/openrewrite/rewrite-jackson/issues/17")
     @Test
     void replaceWithSetConfigCallGeneric() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/jackson/codehaus/CodehausToFasterXMLTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/CodehausToFasterXMLTest.java
@@ -17,6 +17,8 @@ package org.openrewrite.java.jackson.codehaus;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
@@ -333,62 +335,68 @@ class CodehausToFasterXMLTest implements RewriteTest {
     }
 
     @Issue("https://github.com/openrewrite/rewrite-jackson/issues/17")
-    @Issue("https://github.com/openrewrite/rewrite-jackson/issues/17")
-    @Test
-    void replaceWithSetConfigCallGeneric() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import org.codehaus.jackson.map.AnnotationIntrospector;
-              import org.codehaus.jackson.map.ObjectMapper;
+    @Nested
+    class AnnotationIntrospector {
 
-              class Test {
-                  void method(ObjectMapper mapper, AnnotationIntrospector introspector) {
-                      mapper.getSerializationConfig().setAnnotationIntrospector(introspector);
+        @Test
+        void replaceWithSetConfigCallGeneric() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import org.codehaus.jackson.map.AnnotationIntrospector;
+                  import org.codehaus.jackson.map.ObjectMapper;
+
+                  class Test {
+                      void method(ObjectMapper mapper, AnnotationIntrospector introspector) {
+                          mapper.getSerializationConfig().setAnnotationIntrospector(introspector);
+                      }
                   }
-              }
-              """,
-            """
-              import com.fasterxml.jackson.databind.AnnotationIntrospector;
-              import com.fasterxml.jackson.databind.ObjectMapper;
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.AnnotationIntrospector;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
 
-              class Test {
-                  void method(ObjectMapper mapper, AnnotationIntrospector introspector) {
-                      mapper.setConfig(mapper.getSerializationConfig().with(introspector));
+                  class Test {
+                      void method(ObjectMapper mapper, AnnotationIntrospector introspector) {
+                          mapper.setConfig(mapper.getSerializationConfig().with(introspector));
+                      }
                   }
-              }
-              """
-          )
-        );
-    }
+                  """
+              )
+            );
+        }
 
-    @Test
-    void replaceWithSetConfigCallJaxB() {
-        rewriteRun(
-          //language=java
-          java(
-            """
-              import org.codehaus.jackson.map.ObjectMapper;
-              import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+          org.codehaus.jackson.xc.JaxbAnnotationIntrospector, com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector
+          org.codehaus.jackson.map.introspect.JacksonAnnotationIntrospector, com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector
+          org.codehaus.jackson.map.introspect.NopAnnotationIntrospector, com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector
+          """) // org.codehaus.jackson.map.AnnotationIntrospector.Pair, com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair
+        void replaceWithSetConfigCallJaxB(String codehausClass, String fasterXmlClass) {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import %s;
 
-              class Test {
-                  void method(ObjectMapper mapper, JaxbAnnotationIntrospector introspector) {
-                      mapper.getSerializationConfig().setAnnotationIntrospector(introspector);
+                  class Test {
+                      void method(org.codehaus.jackson.map.ObjectMapper mapper, %s introspector) {
+                          mapper.getSerializationConfig().setAnnotationIntrospector(introspector);
+                      }
                   }
-              }
-              """,
-            """
-              import com.fasterxml.jackson.databind.ObjectMapper;
-              import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+                  """.formatted(codehausClass, codehausClass.substring(codehausClass.lastIndexOf('.') + 1)),
+                """
+                  import %s;
 
-              class Test {
-                  void method(ObjectMapper mapper, JaxbAnnotationIntrospector introspector) {
-                      mapper.setConfig(mapper.getSerializationConfig().with(introspector));
+                  class Test {
+                      void method(com.fasterxml.jackson.databind.ObjectMapper mapper, %s introspector) {
+                          mapper.setConfig(mapper.getSerializationConfig().with(introspector));
+                      }
                   }
-              }
-              """
-          )
-        );
+                  """.formatted(fasterXmlClass, fasterXmlClass.substring(fasterXmlClass.lastIndexOf('.') + 1))
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
The API for setting the serialization configuration has changed in fasterXML, no longer allowing in-place. This recipe will replacing existing call with the new API as outlined in 
- #17.

## Anything in particular you'd like reviewers to focus on?
## Anyone you would like to review specifically?
@timtebeek 

## Have you considered any alternatives or workarounds?
## Any additional context

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
