### PR TITLE
remove obsolete "java 8" module dependencies

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -40,6 +40,24 @@ recipeList:
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
       newVersion: 3.0.0-rc4
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.module
+      oldArtifactId: jackson-module-parameter-names
+      newGroupId: tools.jackson.core
+      newArtifactId: jackson-databind
+      newVersion: 3.0.0-rc4
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.datatype
+      oldArtifactId: jackson-datatype-jdk8
+      newGroupId: tools.jackson.core
+      newArtifactId: jackson-databind
+      newVersion: 3.0.0-rc4
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.datatype
+      oldArtifactId: jackson-datatype-jsr310
+      newGroupId: tools.jackson.core
+      newArtifactId: jackson-databind
+      newVersion: 3.0.0-rc4
   - org.openrewrite.java.ChangePackage:
       oldPackageName: com.fasterxml.jackson.core
       newPackageName: tools.jackson.core

--- a/src/test/java/org/openrewrite/jackson/UpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/jackson/UpgradeJackson_2_3Test.java
@@ -70,6 +70,21 @@ class UpgradeJackson_2_3Test implements RewriteTest {
                                      <artifactId>jackson-databind</artifactId>
                                      <version>2.19.0</version>
                                  </dependency>
+                                 <dependency>
+                                     <groupId>com.fasterxml.jackson.module</groupId>
+                                     <artifactId>jackson-module-parameter-names</artifactId>
+                                     <version>2.19.0</version>
+                                 </dependency>
+                                 <dependency>
+                                     <groupId>com.fasterxml.jackson.datatype</groupId>
+                                     <artifactId>jackson-datatype-jdk8</artifactId>
+                                     <version>2.19.0</version>
+                                 </dependency>
+                                 <dependency>
+                                     <groupId>com.fasterxml.jackson.datatype</groupId>
+                                     <artifactId>jackson-datatype-jsr310</artifactId>
+                                     <version>2.19.0</version>
+                                 </dependency>
                              </dependencies>
                          </project>
                          """,
@@ -145,6 +160,64 @@ class UpgradeJackson_2_3Test implements RewriteTest {
               }
               """
           )
+        );
+    }
+
+    @Test
+    void jacksonUpgradeToVersion3_java8Only() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+                       <project>
+                           <modelVersion>4.0.0</modelVersion>
+                           <groupId>org.example</groupId>
+                           <artifactId>example</artifactId>
+                           <version>1.0.0</version>
+                           <dependencies>
+                               <dependency>
+                                   <groupId>com.fasterxml.jackson.module</groupId>
+                                   <artifactId>jackson-module-parameter-names</artifactId>
+                                   <version>2.19.0</version>
+                               </dependency>
+                               <dependency>
+                                   <groupId>com.fasterxml.jackson.datatype</groupId>
+                                   <artifactId>jackson-datatype-jdk8</artifactId>
+                                   <version>2.19.0</version>
+                               </dependency>
+                               <dependency>
+                                   <groupId>com.fasterxml.jackson.datatype</groupId>
+                                   <artifactId>jackson-datatype-jsr310</artifactId>
+                                   <version>2.19.0</version>
+                               </dependency>
+                           </dependencies>
+                       </project>
+                       """,
+            spec -> spec.after(pom -> {
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                String jacksonVersion = versionMatcher.group(0);
+
+                Matcher annotationsVersionMatcher = Pattern.compile("3\\.\\d+(\\.\\d+)*(-rc[\\d]*)?").matcher(pom);
+                assertThat(annotationsVersionMatcher.find()).describedAs("Expected 3.x in %s", pom).isTrue();
+                String annotationsVersion = annotationsVersionMatcher.group(0);
+
+                return """
+                         <project>
+                             <modelVersion>4.0.0</modelVersion>
+                             <groupId>org.example</groupId>
+                             <artifactId>example</artifactId>
+                             <version>1.0.0</version>
+                             <dependencies>
+                                 <dependency>
+                                     <groupId>tools.jackson.core</groupId>
+                                     <artifactId>jackson-databind</artifactId>
+                                     <version>%s</version>
+                                 </dependency>
+                             </dependencies>
+                         </project>
+                  """.formatted(annotationsVersion, jacksonVersion, jacksonVersion);
+            }))
         );
     }
 }


### PR DESCRIPTION


## What's changed?
remove obsolete "java 8" module dependencies and replace with jackson-databind

these modules were merged with jackson-databind according to point 4 of https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0#major-changesfeatures-in-30

## What's your motivation?
increase coverage of jackson 3 changes

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
