### PR TITLE
Add recipes for Jackson 3.x exception changes

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -24,6 +24,7 @@ description: Migrate applications to the latest Jackson 3.x release.
 tags:
   - jackson
 recipeList:
+  - "org.openrewrite.jackson.UpgradeJackson_2_And_3_Base_Exceptions"
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: com.fasterxml.jackson.core
       artifactId: jackson-annotations
@@ -58,6 +59,12 @@ recipeList:
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
       newVersion: 3.0.0-rc4
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.core.JsonParseException
+      newFullyQualifiedTypeName: tools.jackson.core.StreamReadException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.core.JsonGenerationException
+      newFullyQualifiedTypeName: tools.jackson.core.StreamWriteException
   - org.openrewrite.java.ChangePackage:
       oldPackageName: com.fasterxml.jackson.core
       newPackageName: tools.jackson.core

--- a/src/main/resources/META-INF/rewrite/jackson-2-and-3-base-exceptions.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-and-3-base-exceptions.yml
@@ -1,0 +1,32 @@
+#
+# Copyright 2025 original author or authors.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+########################################################################################################################
+# Jackson library
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.jackson.UpgradeJackson_2_And_3_Base_Exceptions
+displayName: Migrates Jackson 2.x base exceptions to Jackson 3.x base exceptions
+description: Jackson 3 contains new base exceptions which were also backported to 2.x. This recipe will migrate usage to the new base exceptions to prepare for a 3.x upgrade.
+tags:
+  - jackson
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.core.JsonProcessingException
+      newFullyQualifiedTypeName: com.fasterxml.jackson.core.JacksonException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.databind.JsonMappingException
+      newFullyQualifiedTypeName: com.fasterxml.jackson.databind.DatabindException

--- a/src/test/java/org/openrewrite/jackson/UpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/jackson/UpgradeJackson_2_3Test.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.jackson;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.config.Environment;
@@ -24,10 +22,12 @@ import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.maven.Assertions.pomXml;
-
 
 class UpgradeJackson_2_3Test implements RewriteTest {
     @Override
@@ -48,46 +48,46 @@ class UpgradeJackson_2_3Test implements RewriteTest {
         rewriteRun(
           //language=xml
           pomXml(
-              """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>com.fasterxml.jackson.core</groupId>
-                                     <artifactId>jackson-annotations</artifactId>
-                                     <version>2.19.0</version>
-                                 </dependency>
-                                 <dependency>
-                                     <groupId>com.fasterxml.jackson.core</groupId>
-                                     <artifactId>jackson-core</artifactId>
-                                     <version>2.19.0</version>
-                                 </dependency>
-                                 <dependency>
-                                     <groupId>com.fasterxml.jackson.core</groupId>
-                                     <artifactId>jackson-databind</artifactId>
-                                     <version>2.19.0</version>
-                                 </dependency>
-                                 <dependency>
-                                     <groupId>com.fasterxml.jackson.module</groupId>
-                                     <artifactId>jackson-module-parameter-names</artifactId>
-                                     <version>2.19.0</version>
-                                 </dependency>
-                                 <dependency>
-                                     <groupId>com.fasterxml.jackson.datatype</groupId>
-                                     <artifactId>jackson-datatype-jdk8</artifactId>
-                                     <version>2.19.0</version>
-                                 </dependency>
-                                 <dependency>
-                                     <groupId>com.fasterxml.jackson.datatype</groupId>
-                                     <artifactId>jackson-datatype-jsr310</artifactId>
-                                     <version>2.19.0</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
-                         """,
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.core</groupId>
+                          <artifactId>jackson-annotations</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.core</groupId>
+                          <artifactId>jackson-core</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.core</groupId>
+                          <artifactId>jackson-databind</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.module</groupId>
+                          <artifactId>jackson-module-parameter-names</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.datatype</groupId>
+                          <artifactId>jackson-datatype-jdk8</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.datatype</groupId>
+                          <artifactId>jackson-datatype-jsr310</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
             spec -> spec.after(pom -> {
                 Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
@@ -130,12 +130,12 @@ class UpgradeJackson_2_3Test implements RewriteTest {
               import com.fasterxml.jackson.core.JsonFactory;
               import com.fasterxml.jackson.core.JsonFactoryBuilder;
               import com.fasterxml.jackson.databind.ObjectMapper;
-
+              
               class Test {
                   public String foo(@JsonProperty("foo") String foo) {
                       return foo;
                   }
-
+              
                   static void helloJackson() {
                       Object[] input = new Object[] { "one", "two" };
                       JsonFactory factory = new JsonFactoryBuilder().build();
@@ -147,12 +147,12 @@ class UpgradeJackson_2_3Test implements RewriteTest {
               import tools.jackson.core.JsonFactory;
               import tools.jackson.core.JsonFactoryBuilder;
               import tools.jackson.databind.ObjectMapper;
-
+              
               class Test {
                   public String foo(@JsonProperty("foo") String foo) {
                       return foo;
                   }
-
+              
                   static void helloJackson() {
                       Object[] input = new Object[] { "one", "two" };
                       JsonFactory factory = new JsonFactoryBuilder().build();
@@ -169,30 +169,30 @@ class UpgradeJackson_2_3Test implements RewriteTest {
           //language=xml
           pomXml(
             """
-                       <project>
-                           <modelVersion>4.0.0</modelVersion>
-                           <groupId>org.example</groupId>
-                           <artifactId>example</artifactId>
-                           <version>1.0.0</version>
-                           <dependencies>
-                               <dependency>
-                                   <groupId>com.fasterxml.jackson.module</groupId>
-                                   <artifactId>jackson-module-parameter-names</artifactId>
-                                   <version>2.19.0</version>
-                               </dependency>
-                               <dependency>
-                                   <groupId>com.fasterxml.jackson.datatype</groupId>
-                                   <artifactId>jackson-datatype-jdk8</artifactId>
-                                   <version>2.19.0</version>
-                               </dependency>
-                               <dependency>
-                                   <groupId>com.fasterxml.jackson.datatype</groupId>
-                                   <artifactId>jackson-datatype-jsr310</artifactId>
-                                   <version>2.19.0</version>
-                               </dependency>
-                           </dependencies>
-                       </project>
-                       """,
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.module</groupId>
+                          <artifactId>jackson-module-parameter-names</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.datatype</groupId>
+                          <artifactId>jackson-datatype-jdk8</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.datatype</groupId>
+                          <artifactId>jackson-datatype-jsr310</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
             spec -> spec.after(pom -> {
                 Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
@@ -218,6 +218,170 @@ class UpgradeJackson_2_3Test implements RewriteTest {
                          </project>
                   """.formatted(annotationsVersion, jacksonVersion, jacksonVersion);
             }))
+        );
+    }
+
+    @Test
+    void jacksonUpgradeToVersion3_JsonProcessingException() {
+        rewriteRun(
+          //language=java
+          java(
+          """
+            import com.fasterxml.jackson.core.JsonFactory;
+            import com.fasterxml.jackson.core.JsonFactoryBuilder;
+            import com.fasterxml.jackson.core.JsonProcessingException;
+            import com.fasterxml.jackson.databind.ObjectMapper;
+            
+            class Test {
+                static void helloJackson() {
+                    try {
+                        Object[] input = new Object[] { "one", "two" };
+                        JsonFactory factory = new JsonFactoryBuilder().build();
+                    } catch (JsonProcessingException e) {
+                    }
+                }
+            }
+            """,
+          """
+            import tools.jackson.core.JacksonException;
+            import tools.jackson.core.JsonFactory;
+            import tools.jackson.core.JsonFactoryBuilder;
+            import tools.jackson.databind.ObjectMapper;
+            
+            class Test {
+                static void helloJackson() {
+                    try {
+                        Object[] input = new Object[] { "one", "two" };
+                        JsonFactory factory = new JsonFactoryBuilder().build();
+                    } catch (JacksonException e) {
+                    }
+                }
+            }
+            """
+        )
+        );
+    }
+
+    @Test
+    void jacksonUpgradeToVersion3_JsonParseException() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonFactory;
+              import com.fasterxml.jackson.core.JsonFactoryBuilder;
+              import com.fasterxml.jackson.core.JsonParseException;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              
+              class Test {
+                  static void helloJackson() {
+                      try {
+                          Object[] input = new Object[] { "one", "two" };
+                          JsonFactory factory = new JsonFactoryBuilder().build();
+                      } catch (JsonParseException e) {
+                      }
+                  }
+              }
+              """,
+            """
+              import tools.jackson.core.JsonFactory;
+              import tools.jackson.core.JsonFactoryBuilder;
+              import tools.jackson.databind.ObjectMapper;
+              import tools.jackson.core.StreamReadException;
+              
+              class Test {
+                  static void helloJackson() {
+                      try {
+                          Object[] input = new Object[] { "one", "two" };
+                          JsonFactory factory = new JsonFactoryBuilder().build();
+                      } catch (StreamReadException e) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jacksonUpgradeToVersion3_JsonGenerationException() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonFactory;
+              import com.fasterxml.jackson.core.JsonFactoryBuilder;
+              import com.fasterxml.jackson.core.JsonGenerationException;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              
+              class Test {
+                  static void helloJackson() {
+                      try {
+                          Object[] input = new Object[] { "one", "two" };
+                          JsonFactory factory = new JsonFactoryBuilder().build();
+                      } catch (JsonGenerationException e) {
+                      }
+                  }
+              }
+              """,
+            """
+              import tools.jackson.core.JsonFactory;
+              import tools.jackson.core.JsonFactoryBuilder;
+              import tools.jackson.databind.ObjectMapper;
+              import tools.jackson.core.StreamWriteException;
+              
+              class Test {
+                  static void helloJackson() {
+                      try {
+                          Object[] input = new Object[] { "one", "two" };
+                          JsonFactory factory = new JsonFactoryBuilder().build();
+                      } catch (StreamWriteException e) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jacksonUpgradeToVersion3_JsonMappingException() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonFactory;
+              import com.fasterxml.jackson.core.JsonFactoryBuilder;
+              import com.fasterxml.jackson.databind.JsonMappingException;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              
+              class Test {
+                  static void helloJackson() {
+                      try {
+                          Object[] input = new Object[] { "one", "two" };
+                          JsonFactory factory = new JsonFactoryBuilder().build();
+                      } catch (JsonMappingException e) {
+                      }
+                  }
+              }
+              """,
+            """
+              import tools.jackson.core.JsonFactory;
+              import tools.jackson.core.JsonFactoryBuilder;
+              import tools.jackson.databind.DatabindException;
+              import tools.jackson.databind.ObjectMapper;
+              
+              class Test {
+                  static void helloJackson() {
+                      try {
+                          Object[] input = new Object[] { "one", "two" };
+                          JsonFactory factory = new JsonFactoryBuilder().build();
+                      } catch (DatabindException e) {
+                      }
+                  }
+              }
+              """
+          )
         );
     }
 }

--- a/src/test/java/org/openrewrite/jackson/UpgradeJackson_2_And_3_Base_ExceptionsTest.java
+++ b/src/test/java/org/openrewrite/jackson/UpgradeJackson_2_And_3_Base_ExceptionsTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.jackson;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class UpgradeJackson_2_And_3_Base_ExceptionsTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion().classpath(
+            "jackson-annotations", "jackson-core", "jackson-databind"))
+          .recipe(Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite")
+            .build()
+            .activateRecipes("org.openrewrite.jackson.UpgradeJackson_2_And_3_Base_Exceptions")
+          );
+    }
+
+    @DocumentExample
+    @Test
+    void jacksonUpgradeToNewBaseExceptions() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonProcessingException;
+              import com.fasterxml.jackson.databind.JsonMappingException;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              
+              class Test {
+                  static void helloJackson() {
+                      ObjectMapper objectMapper = new ObjectMapper();
+                      Object object = new Object();
+                      try {
+                          String json = objectMapper.writeValueAsString(object);
+                          try {
+                              objectMapper.readValue(json, Object.class);
+                          } catch (JsonMappingException e) {
+                              throw new RuntimeException(e);
+                          }
+                      } catch (JsonProcessingException e) {
+                          throw new RuntimeException(e);
+                      }
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.core.JacksonException;
+              import com.fasterxml.jackson.databind.DatabindException;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              
+              class Test {
+                  static void helloJackson() {
+                      ObjectMapper objectMapper = new ObjectMapper();
+                      Object object = new Object();
+                      try {
+                          String json = objectMapper.writeValueAsString(object);
+                          try {
+                              objectMapper.readValue(json, Object.class);
+                          } catch (DatabindException e) {
+                              throw new RuntimeException(e);
+                          }
+                      } catch (JacksonException e) {
+                          throw new RuntimeException(e);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jacksonUpgradeToVersion3_JsonProcessingException() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonFactory;
+              import com.fasterxml.jackson.core.JsonFactoryBuilder;
+              import com.fasterxml.jackson.core.JsonProcessingException;
+              
+              class Test {
+                  static void helloJackson() {
+                      try {
+                          Object[] input = new Object[] { "one", "two" };
+                          JsonFactory factory = new JsonFactoryBuilder().build();
+                      } catch (JsonProcessingException e) {
+                      }
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.core.JacksonException;
+              import com.fasterxml.jackson.core.JsonFactory;
+              import com.fasterxml.jackson.core.JsonFactoryBuilder;
+              
+              class Test {
+                  static void helloJackson() {
+                      try {
+                          Object[] input = new Object[] { "one", "two" };
+                          JsonFactory factory = new JsonFactoryBuilder().build();
+                      } catch (JacksonException e) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jacksonUpgradeToVersion3_JsonMappingException() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonFactory;
+              import com.fasterxml.jackson.core.JsonFactoryBuilder;
+              import com.fasterxml.jackson.databind.JsonMappingException;
+              
+              class Test {
+                  static void helloJackson() {
+                      try {
+                          Object[] input = new Object[] { "one", "two" };
+                          JsonFactory factory = new JsonFactoryBuilder().build();
+                      } catch (JsonMappingException e) {
+                      }
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.core.JsonFactory;
+              import com.fasterxml.jackson.core.JsonFactoryBuilder;
+              import com.fasterxml.jackson.databind.DatabindException;
+              
+              class Test {
+                  static void helloJackson() {
+                      try {
+                          Object[] input = new Object[] { "one", "two" };
+                          JsonFactory factory = new JsonFactoryBuilder().build();
+                      } catch (DatabindException e) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION

## What's changed?
Make changes to exception usage according to point 7 of https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0#major-changesfeatures-in-30 with additional details in https://github.com/FasterXML/jackson-future-ideas/wiki/JSTEP-4


## What's your motivation?
increase coverage of jackson 2->3 migration


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
