### PR TITLE
update for jackson 3.0.0-rc10

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -34,37 +34,37 @@ recipeList:
       oldArtifactId: jackson-core
       newGroupId: tools.jackson.core
       newArtifactId: jackson-core
-      newVersion: 3.0.0-rc9
+      newVersion: 3.0.0-rc10
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson
       oldArtifactId: jackson-bom
       newGroupId: tools.jackson
       newArtifactId: jackson-bom
-      newVersion: 3.0.0-rc9
+      newVersion: 3.0.0-rc10
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.core
       oldArtifactId: jackson-databind
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
-      newVersion: 3.0.0-rc9
+      newVersion: 3.0.0-rc10
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-parameter-names
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
-      newVersion: 3.0.0-rc9
+      newVersion: 3.0.0-rc10
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.datatype
       oldArtifactId: jackson-datatype-jdk8
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
-      newVersion: 3.0.0-rc9
+      newVersion: 3.0.0-rc10
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.datatype
       oldArtifactId: jackson-datatype-jsr310
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
-      newVersion: 3.0.0-rc9
+      newVersion: 3.0.0-rc10
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.core.JsonParseException
       newFullyQualifiedTypeName: tools.jackson.core.StreamReadException


### PR DESCRIPTION
# details

upgrade to latest jackson 3.0.0 release candidate

# reference

https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0

https://bsky.app/profile/cowtowncoder.bsky.social/post/3lzafjxlq6c2k

https://repo1.maven.org/maven2/tools/jackson/jackson-bom/3.0.0-rc10/

