### PR TITLE
support jackson-dataformat-yaml migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     testRuntimeOnly("org.codehaus.jackson:jackson-core-asl:latest.release")
     testRuntimeOnly("org.codehaus.jackson:jackson-mapper-asl:latest.release")
     testRuntimeOnly("org.codehaus.jackson:jackson-xc:latest.release")
+    testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:latest.release")
 }
 
 recipeDependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     testRuntimeOnly("org.codehaus.jackson:jackson-core-asl:latest.release")
     testRuntimeOnly("org.codehaus.jackson:jackson-mapper-asl:latest.release")
     testRuntimeOnly("org.codehaus.jackson:jackson-xc:latest.release")
-    testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:latest.release")
+    testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.3")
 }
 
 recipeDependencies {

--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -73,6 +73,12 @@ recipeList:
       newArtifactId: jackson-databind
       newVersion: 3.0.x
   - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.dataformat
+      oldArtifactId: jackson-dataformat-yaml
+      newGroupId: tools.jackson.dataformat
+      newArtifactId: jackson-dataformat-yaml
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.datatype
       oldArtifactId: jackson-datatype-jdk8
       newGroupId: tools.jackson.core
@@ -94,6 +100,12 @@ description: Update Jackson type names including exception types and core class 
 tags:
   - jackson-3
 recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.yaml.YAMLParser$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.yaml.YAMLReadFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.yaml.YAMLGenerator$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.yaml.YAMLWriteFeature
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.core.JsonParseException
       newFullyQualifiedTypeName: tools.jackson.core.StreamReadException

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
@@ -344,4 +344,48 @@ class Jackson3DependenciesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void jacksonDataformatYaml() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.dataformat</groupId>
+                          <artifactId>jackson-dataformat-yaml</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                String jacksonVersion = versionMatcher.group(0);
+                return """
+                         <project>
+                             <modelVersion>4.0.0</modelVersion>
+                             <groupId>org.example</groupId>
+                             <artifactId>example</artifactId>
+                             <version>1.0.0</version>
+                             <dependencies>
+                                 <dependency>
+                                     <groupId>tools.jackson.dataformat</groupId>
+                                     <artifactId>jackson-dataformat-yaml</artifactId>
+                                     <version>%s</version>
+                                 </dependency>
+                             </dependencies>
+                         </project>
+                  """.formatted(jacksonVersion);
+            })
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
@@ -29,7 +29,7 @@ class Jackson3TypeChangesTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.java.jackson.UpgradeJackson_2_3")
           .parser(JavaParser.fromJavaVersion().classpath(
-            "jackson-annotations", "jackson-core", "jackson-databind"));
+            "jackson-annotations", "jackson-core", "jackson-databind", "jackson-dataformat-yaml"));
     }
 
     @DocumentExample
@@ -223,6 +223,33 @@ class Jackson3TypeChangesTest implements RewriteTest {
                   public String getModuleName() {
                       return "custom";
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void yaml() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.dataformat.yaml.YAMLParser.Feature;
+              import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature;
+
+              class YamlThings {
+                  public final YAMLParser.Feature readFeature = YAMLParser.Feature.EMPTY_STRING_AS_NULL;
+                  public final YAMLGenerator.Feature writeFeature = YAMLGenerator.Feature.MINIMIZE_QUOTES;
+              }
+              """,
+            """
+              import tools.jackson.dataformat.yaml.YAMLReadFeature;
+              import tools.jackson.dataformat.yaml.YAMLWriteFeature;
+
+              class YamlThings {
+                  public final YAMLReadFeature readFeature = YAMLReadFeature.EMPTY_STRING_AS_NULL;
+                  public final YAMLWriteFeature writeFeature = YAMLWriteFeature.MINIMIZE_QUOTES;
               }
               """
           )

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
@@ -29,7 +29,10 @@ class Jackson3TypeChangesTest implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec.recipeFromResources("org.openrewrite.java.jackson.UpgradeJackson_2_3")
           .parser(JavaParser.fromJavaVersion().classpath(
-            "jackson-annotations", "jackson-core", "jackson-databind", "jackson-dataformat-yaml"));
+            "jackson-annotations",
+            "jackson-core",
+            "jackson-databind",
+            "jackson-dataformat-yaml"));
     }
 
     @DocumentExample

--- a/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
@@ -94,29 +94,29 @@ class UpgradeJackson_2_3Test implements RewriteTest {
                 String jacksonVersion = versionMatcher.group(0);
 
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>com.fasterxml.jackson.core</groupId>
-                                     <artifactId>jackson-annotations</artifactId>
-                                     <version>2.20</version>
-                                 </dependency>
-                                 <dependency>
-                                     <groupId>tools.jackson.core</groupId>
-                                     <artifactId>jackson-core</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                                 <dependency>
-                                     <groupId>tools.jackson.core</groupId>
-                                     <artifactId>jackson-databind</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>com.fasterxml.jackson.core</groupId>
+                              <artifactId>jackson-annotations</artifactId>
+                              <version>2.20</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>tools.jackson.core</groupId>
+                              <artifactId>jackson-core</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                          <dependency>
+                              <groupId>tools.jackson.core</groupId>
+                              <artifactId>jackson-databind</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
                   """.formatted(jacksonVersion, jacksonVersion);
             })),
           //language=java


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

adding support for jackson-dataformat-yaml 

## What's your motivation?

jackson 3.0.0 has new package names and artifact names

## jackson 3 API

- https://www.javadoc.io/doc/tools.jackson.dataformat/jackson-dataformat-yaml/latest/tools.jackson.dataformat.yaml/tools/jackson/dataformat/yaml/YAMLReadFeature.html
- https://www.javadoc.io/doc/tools.jackson.dataformat/jackson-dataformat-yaml/latest/tools.jackson.dataformat.yaml/tools/jackson/dataformat/yaml/YAMLWriteFeature.html

## Maven Central artifacts

- https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/
- https://repo1.maven.org/maven2/tools/jackson/dataformat/jackson-dataformat-yaml/

## Any additional context

- https://cowtowncoder.medium.com/jackson-3-0-0-ga-released-1f669cda529a


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
