### PR TITLE
Add Jackson 3 migration support for 6 additional dataformat modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,12 @@ dependencies {
     testRuntimeOnly("org.codehaus.jackson:jackson-mapper-asl:latest.release")
     testRuntimeOnly("org.codehaus.jackson:jackson-xc:latest.release")
     testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.3")
+    testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.3")
+    testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.17.3")
+    testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.17.3")
+    testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-avro:2.17.3")
+    testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.17.3")
+    testRuntimeOnly("com.fasterxml.jackson.dataformat:jackson-dataformat-ion:2.17.3")
 }
 
 recipeDependencies {

--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -79,6 +79,42 @@ recipeList:
       newArtifactId: jackson-dataformat-yaml
       newVersion: 3.0.x
   - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.dataformat
+      oldArtifactId: jackson-dataformat-xml
+      newGroupId: tools.jackson.dataformat
+      newArtifactId: jackson-dataformat-xml
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.dataformat
+      oldArtifactId: jackson-dataformat-csv
+      newGroupId: tools.jackson.dataformat
+      newArtifactId: jackson-dataformat-csv
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.dataformat
+      oldArtifactId: jackson-dataformat-cbor
+      newGroupId: tools.jackson.dataformat
+      newArtifactId: jackson-dataformat-cbor
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.dataformat
+      oldArtifactId: jackson-dataformat-avro
+      newGroupId: tools.jackson.dataformat
+      newArtifactId: jackson-dataformat-avro
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.dataformat
+      oldArtifactId: jackson-dataformat-smile
+      newGroupId: tools.jackson.dataformat
+      newArtifactId: jackson-dataformat-smile
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.dataformat
+      oldArtifactId: jackson-dataformat-ion
+      newGroupId: tools.jackson.dataformat
+      newArtifactId: jackson-dataformat-ion
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.datatype
       oldArtifactId: jackson-datatype-jdk8
       newGroupId: tools.jackson.core
@@ -106,6 +142,39 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.yaml.YAMLGenerator$Feature
       newFullyQualifiedTypeName: tools.jackson.dataformat.yaml.YAMLWriteFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.xml.XmlReadFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.xml.XmlWriteFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.csv.CsvParser$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.csv.CsvReadFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.csv.CsvGenerator$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.csv.CsvWriteFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.cbor.CBORGenerator$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.cbor.CBORWriteFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.avro.AvroParser$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.avro.AvroReadFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.avro.AvroGenerator$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.avro.AvroWriteFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.smile.SmileParser$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.smile.SmileReadFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.smile.SmileGenerator$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.smile.SmileWriteFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.ion.IonParser$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.ion.IonReadFeature
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.dataformat.ion.IonGenerator$Feature
+      newFullyQualifiedTypeName: tools.jackson.dataformat.ion.IonWriteFeature
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.core.JsonParseException
       newFullyQualifiedTypeName: tools.jackson.core.StreamReadException

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
@@ -388,4 +388,268 @@ class Jackson3DependenciesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void jacksonDataformatXml() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.dataformat</groupId>
+                          <artifactId>jackson-dataformat-xml</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                String jacksonVersion = versionMatcher.group(0);
+                return """
+                         <project>
+                             <modelVersion>4.0.0</modelVersion>
+                             <groupId>org.example</groupId>
+                             <artifactId>example</artifactId>
+                             <version>1.0.0</version>
+                             <dependencies>
+                                 <dependency>
+                                     <groupId>tools.jackson.dataformat</groupId>
+                                     <artifactId>jackson-dataformat-xml</artifactId>
+                                     <version>%s</version>
+                                 </dependency>
+                             </dependencies>
+                         </project>
+                  """.formatted(jacksonVersion);
+            })
+          )
+        );
+    }
+
+    @Test
+    void jacksonDataformatCsv() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.dataformat</groupId>
+                          <artifactId>jackson-dataformat-csv</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                String jacksonVersion = versionMatcher.group(0);
+                return """
+                         <project>
+                             <modelVersion>4.0.0</modelVersion>
+                             <groupId>org.example</groupId>
+                             <artifactId>example</artifactId>
+                             <version>1.0.0</version>
+                             <dependencies>
+                                 <dependency>
+                                     <groupId>tools.jackson.dataformat</groupId>
+                                     <artifactId>jackson-dataformat-csv</artifactId>
+                                     <version>%s</version>
+                                 </dependency>
+                             </dependencies>
+                         </project>
+                  """.formatted(jacksonVersion);
+            })
+          )
+        );
+    }
+
+    @Test
+    void jacksonDataformatCbor() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.dataformat</groupId>
+                          <artifactId>jackson-dataformat-cbor</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                String jacksonVersion = versionMatcher.group(0);
+                return """
+                         <project>
+                             <modelVersion>4.0.0</modelVersion>
+                             <groupId>org.example</groupId>
+                             <artifactId>example</artifactId>
+                             <version>1.0.0</version>
+                             <dependencies>
+                                 <dependency>
+                                     <groupId>tools.jackson.dataformat</groupId>
+                                     <artifactId>jackson-dataformat-cbor</artifactId>
+                                     <version>%s</version>
+                                 </dependency>
+                             </dependencies>
+                         </project>
+                  """.formatted(jacksonVersion);
+            })
+          )
+        );
+    }
+
+    @Test
+    void jacksonDataformatAvro() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.dataformat</groupId>
+                          <artifactId>jackson-dataformat-avro</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                String jacksonVersion = versionMatcher.group(0);
+                return """
+                         <project>
+                             <modelVersion>4.0.0</modelVersion>
+                             <groupId>org.example</groupId>
+                             <artifactId>example</artifactId>
+                             <version>1.0.0</version>
+                             <dependencies>
+                                 <dependency>
+                                     <groupId>tools.jackson.dataformat</groupId>
+                                     <artifactId>jackson-dataformat-avro</artifactId>
+                                     <version>%s</version>
+                                 </dependency>
+                             </dependencies>
+                         </project>
+                  """.formatted(jacksonVersion);
+            })
+          )
+        );
+    }
+
+    @Test
+    void jacksonDataformatSmile() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.dataformat</groupId>
+                          <artifactId>jackson-dataformat-smile</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                String jacksonVersion = versionMatcher.group(0);
+                return """
+                         <project>
+                             <modelVersion>4.0.0</modelVersion>
+                             <groupId>org.example</groupId>
+                             <artifactId>example</artifactId>
+                             <version>1.0.0</version>
+                             <dependencies>
+                                 <dependency>
+                                     <groupId>tools.jackson.dataformat</groupId>
+                                     <artifactId>jackson-dataformat-smile</artifactId>
+                                     <version>%s</version>
+                                 </dependency>
+                             </dependencies>
+                         </project>
+                  """.formatted(jacksonVersion);
+            })
+          )
+        );
+    }
+
+    @Test
+    void jacksonDataformatIon() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.dataformat</groupId>
+                          <artifactId>jackson-dataformat-ion</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                String jacksonVersion = versionMatcher.group(0);
+                return """
+                         <project>
+                             <modelVersion>4.0.0</modelVersion>
+                             <groupId>org.example</groupId>
+                             <artifactId>example</artifactId>
+                             <version>1.0.0</version>
+                             <dependencies>
+                                 <dependency>
+                                     <groupId>tools.jackson.dataformat</groupId>
+                                     <artifactId>jackson-dataformat-ion</artifactId>
+                                     <version>%s</version>
+                                 </dependency>
+                             </dependencies>
+                         </project>
+                  """.formatted(jacksonVersion);
+            })
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.java.jackson;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -345,8 +347,9 @@ class Jackson3DependenciesTest implements RewriteTest {
         );
     }
 
-    @Test
-    void jacksonDataformatYaml() {
+    @ParameterizedTest
+    @ValueSource(strings = {"yaml", "xml", "csv", "cbor", "avro", "smile", "ion"})
+    void jacksonDataformats(String format) {
         rewriteRun(
           //language=xml
           pomXml(
@@ -359,12 +362,12 @@ class Jackson3DependenciesTest implements RewriteTest {
                   <dependencies>
                       <dependency>
                           <groupId>com.fasterxml.jackson.dataformat</groupId>
-                          <artifactId>jackson-dataformat-yaml</artifactId>
+                          <artifactId>jackson-dataformat-%s</artifactId>
                           <version>2.19.0</version>
                       </dependency>
                   </dependencies>
               </project>
-              """,
+              """.formatted(format),
             spec -> spec.after(pom -> {
                 Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
@@ -378,276 +381,12 @@ class Jackson3DependenciesTest implements RewriteTest {
                              <dependencies>
                                  <dependency>
                                      <groupId>tools.jackson.dataformat</groupId>
-                                     <artifactId>jackson-dataformat-yaml</artifactId>
+                                     <artifactId>jackson-dataformat-%s</artifactId>
                                      <version>%s</version>
                                  </dependency>
                              </dependencies>
                          </project>
-                  """.formatted(jacksonVersion);
-            })
-          )
-        );
-    }
-
-    @Test
-    void jacksonDataformatXml() {
-        rewriteRun(
-          //language=xml
-          pomXml(
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>org.example</groupId>
-                  <artifactId>example</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>com.fasterxml.jackson.dataformat</groupId>
-                          <artifactId>jackson-dataformat-xml</artifactId>
-                          <version>2.19.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
-                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
-                String jacksonVersion = versionMatcher.group(0);
-                return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.dataformat</groupId>
-                                     <artifactId>jackson-dataformat-xml</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
-                  """.formatted(jacksonVersion);
-            })
-          )
-        );
-    }
-
-    @Test
-    void jacksonDataformatCsv() {
-        rewriteRun(
-          //language=xml
-          pomXml(
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>org.example</groupId>
-                  <artifactId>example</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>com.fasterxml.jackson.dataformat</groupId>
-                          <artifactId>jackson-dataformat-csv</artifactId>
-                          <version>2.19.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
-                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
-                String jacksonVersion = versionMatcher.group(0);
-                return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.dataformat</groupId>
-                                     <artifactId>jackson-dataformat-csv</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
-                  """.formatted(jacksonVersion);
-            })
-          )
-        );
-    }
-
-    @Test
-    void jacksonDataformatCbor() {
-        rewriteRun(
-          //language=xml
-          pomXml(
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>org.example</groupId>
-                  <artifactId>example</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>com.fasterxml.jackson.dataformat</groupId>
-                          <artifactId>jackson-dataformat-cbor</artifactId>
-                          <version>2.19.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
-                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
-                String jacksonVersion = versionMatcher.group(0);
-                return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.dataformat</groupId>
-                                     <artifactId>jackson-dataformat-cbor</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
-                  """.formatted(jacksonVersion);
-            })
-          )
-        );
-    }
-
-    @Test
-    void jacksonDataformatAvro() {
-        rewriteRun(
-          //language=xml
-          pomXml(
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>org.example</groupId>
-                  <artifactId>example</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>com.fasterxml.jackson.dataformat</groupId>
-                          <artifactId>jackson-dataformat-avro</artifactId>
-                          <version>2.19.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
-                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
-                String jacksonVersion = versionMatcher.group(0);
-                return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.dataformat</groupId>
-                                     <artifactId>jackson-dataformat-avro</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
-                  """.formatted(jacksonVersion);
-            })
-          )
-        );
-    }
-
-    @Test
-    void jacksonDataformatSmile() {
-        rewriteRun(
-          //language=xml
-          pomXml(
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>org.example</groupId>
-                  <artifactId>example</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>com.fasterxml.jackson.dataformat</groupId>
-                          <artifactId>jackson-dataformat-smile</artifactId>
-                          <version>2.19.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
-                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
-                String jacksonVersion = versionMatcher.group(0);
-                return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.dataformat</groupId>
-                                     <artifactId>jackson-dataformat-smile</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
-                  """.formatted(jacksonVersion);
-            })
-          )
-        );
-    }
-
-    @Test
-    void jacksonDataformatIon() {
-        rewriteRun(
-          //language=xml
-          pomXml(
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>org.example</groupId>
-                  <artifactId>example</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>com.fasterxml.jackson.dataformat</groupId>
-                          <artifactId>jackson-dataformat-ion</artifactId>
-                          <version>2.19.0</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
-                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
-                String jacksonVersion = versionMatcher.group(0);
-                return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.dataformat</groupId>
-                                     <artifactId>jackson-dataformat-ion</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
-                  """.formatted(jacksonVersion);
+                  """.formatted(format, jacksonVersion);
             })
           )
         );

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
@@ -32,7 +32,13 @@ class Jackson3TypeChangesTest implements RewriteTest {
             "jackson-annotations",
             "jackson-core",
             "jackson-databind",
-            "jackson-dataformat-yaml"));
+            "jackson-dataformat-yaml",
+            "jackson-dataformat-xml",
+            "jackson-dataformat-csv",
+            "jackson-dataformat-cbor",
+            "jackson-dataformat-avro",
+            "jackson-dataformat-smile",
+            "jackson-dataformat-ion"));
     }
 
     @DocumentExample
@@ -253,6 +259,164 @@ class Jackson3TypeChangesTest implements RewriteTest {
               class YamlThings {
                   public final YAMLReadFeature readFeature = YAMLReadFeature.EMPTY_STRING_AS_NULL;
                   public final YAMLWriteFeature writeFeature = YAMLWriteFeature.MINIMIZE_QUOTES;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void xml() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser;
+              import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+
+              class XmlThings {
+                  public final FromXmlParser.Feature readFeature = FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL;
+                  public final ToXmlGenerator.Feature writeFeature = ToXmlGenerator.Feature.WRITE_XML_DECLARATION;
+              }
+              """,
+            """
+              import tools.jackson.dataformat.xml.XmlReadFeature;
+              import tools.jackson.dataformat.xml.XmlWriteFeature;
+
+              class XmlThings {
+                  public final XmlReadFeature readFeature = XmlReadFeature.EMPTY_ELEMENT_AS_NULL;
+                  public final XmlWriteFeature writeFeature = XmlWriteFeature.WRITE_XML_DECLARATION;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void csv() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.dataformat.csv.CsvParser;
+              import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
+
+              class CsvThings {
+                  public final CsvParser.Feature readFeature = CsvParser.Feature.TRIM_SPACES;
+                  public final CsvGenerator.Feature writeFeature = CsvGenerator.Feature.STRICT_CHECK_FOR_QUOTING;
+              }
+              """,
+            """
+              import tools.jackson.dataformat.csv.CsvReadFeature;
+              import tools.jackson.dataformat.csv.CsvWriteFeature;
+
+              class CsvThings {
+                  public final CsvReadFeature readFeature = CsvReadFeature.TRIM_SPACES;
+                  public final CsvWriteFeature writeFeature = CsvWriteFeature.STRICT_CHECK_FOR_QUOTING;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void cbor() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.dataformat.cbor.CBORGenerator;
+
+              class CborThings {
+                  public final CBORGenerator.Feature writeFeature = CBORGenerator.Feature.WRITE_MINIMAL_INTS;
+              }
+              """,
+            """
+              import tools.jackson.dataformat.cbor.CBORWriteFeature;
+
+              class CborThings {
+                  public final CBORWriteFeature writeFeature = CBORWriteFeature.WRITE_MINIMAL_INTS;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void avro() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.dataformat.avro.AvroParser;
+              import com.fasterxml.jackson.dataformat.avro.AvroGenerator;
+
+              class AvroThings {
+                  public final AvroParser.Feature readFeature = AvroParser.Feature.AVRO_BUFFERING;
+                  public final AvroGenerator.Feature writeFeature = AvroGenerator.Feature.AVRO_FILE_OUTPUT;
+              }
+              """,
+            """
+              import tools.jackson.dataformat.avro.AvroReadFeature;
+              import tools.jackson.dataformat.avro.AvroWriteFeature;
+
+              class AvroThings {
+                  public final AvroReadFeature readFeature = AvroReadFeature.AVRO_BUFFERING;
+                  public final AvroWriteFeature writeFeature = AvroWriteFeature.AVRO_FILE_OUTPUT;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void smile() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.dataformat.smile.SmileParser;
+              import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
+
+              class SmileThings {
+                  public final SmileParser.Feature readFeature = SmileParser.Feature.REQUIRE_HEADER;
+                  public final SmileGenerator.Feature writeFeature = SmileGenerator.Feature.WRITE_HEADER;
+              }
+              """,
+            """
+              import tools.jackson.dataformat.smile.SmileReadFeature;
+              import tools.jackson.dataformat.smile.SmileWriteFeature;
+
+              class SmileThings {
+                  public final SmileReadFeature readFeature = SmileReadFeature.REQUIRE_HEADER;
+                  public final SmileWriteFeature writeFeature = SmileWriteFeature.WRITE_HEADER;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void ion() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.dataformat.ion.IonParser;
+              import com.fasterxml.jackson.dataformat.ion.IonGenerator;
+
+              class IonThings {
+                  public final IonParser.Feature readFeature = IonParser.Feature.USE_NATIVE_TYPE_ID;
+                  public final IonGenerator.Feature writeFeature = IonGenerator.Feature.USE_NATIVE_TYPE_ID;
+              }
+              """,
+            """
+              import tools.jackson.dataformat.ion.IonReadFeature;
+              import tools.jackson.dataformat.ion.IonWriteFeature;
+
+              class IonThings {
+                  public final IonReadFeature readFeature = IonReadFeature.USE_NATIVE_TYPE_ID;
+                  public final IonWriteFeature writeFeature = IonWriteFeature.USE_NATIVE_TYPE_ID;
               }
               """
           )


### PR DESCRIPTION
## Summary

- Following the pattern from PR #28 (YAML migration), this PR adds comprehensive Jackson 3 migration support for **6 additional dataformat modules**:

- **jackson-dataformat-xml** (XML)
- **jackson-dataformat-csv** (CSV)  
- **jackson-dataformat-cbor** (CBOR - binary format)
- **jackson-dataformat-avro** (Avro - binary format)
- **jackson-dataformat-smile** (Smile - binary format)
- **jackson-dataformat-ion** (Ion - binary format)

## Changes

### Recipe Configuration (`jackson-2-3.yml`)
- Added dependency migrations for all 6 dataformat modules
- Added type changes for Feature enum renames following the Jackson 3 pattern:
  - `Parser.Feature` / `Generator.Feature` → `ReadFeature` / `WriteFeature`

### Tests
- Added 6 dependency migration tests in `Jackson3DependenciesTest.java`
- Added 6 type change tests in `Jackson3TypeChangesTest.java`
- Updated test classpath configuration with all new dataformat modules

### Build
- Added test runtime dependencies for all 6 dataformat modules (version 2.17.3)

## Migration Patterns

Each module follows the standard Jackson 3 migration:
- **Group ID**: `com.fasterxml.jackson.dataformat` → `tools.jackson.dataformat`
- **Package**: `com.fasterxml.jackson.dataformat.*` → `tools.jackson.dataformat.*`
- **Feature Enums**: Module-specific Feature classes renamed to ReadFeature/WriteFeature

## Test Results

All new tests pass successfully:
- ✅ 6 dependency migration tests
- ✅ 6 type change tests

## References

- Based on PR #28 for YAML migration
- Aligned with [Jackson 3 Migration Guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)