### PR TITLE
Remove modules folded into jackson-databind

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -128,6 +128,7 @@ recipeList:
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
       newVersion: 3.0.x
+  # Retained for the case where two or more removed modules are present, without jackson-databind
   - org.openrewrite.maven.RemoveDuplicateDependencies
 
 ---

--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -45,6 +45,7 @@ description: Upgrade Jackson Maven dependencies from 2.x to 3.x versions and upd
 tags:
   - jackson-3
 recipeList:
+  - org.openrewrite.java.jackson.UpgradeJackson_2_3_RemoveModules
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: com.fasterxml.jackson.core
       artifactId: jackson-annotations
@@ -128,6 +129,29 @@ recipeList:
       newArtifactId: jackson-databind
       newVersion: 3.0.x
   - org.openrewrite.maven.RemoveDuplicateDependencies
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.jackson.UpgradeJackson_2_3_RemoveModules
+displayName: Remove Jackson 2.x modules included in jackson-databind in 3.x.
+description: Remove Jackson modules such as `jackson-module-parameter-names`, `jackson-datatype-jdk8`, and `jackson-datatype-jsr310` to depend on `jackson-databind` in Jackson 3.x.
+tags:
+  - jackson-3
+preconditions:
+  # When jackson-databind is present, we can remove these dependencies
+  - org.openrewrite.maven.search.FindDependency:
+      groupId: com.fasterxml.jackson.core
+      artifactId: jackson-databind
+recipeList:
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: com.fasterxml.jackson.module
+      artifactId: jackson-module-parameter-names
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: com.fasterxml.jackson.datatype
+      artifactId: jackson-datatype-jdk8
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: com.fasterxml.jackson.datatype
+      artifactId: jackson-datatype-jsr310
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -192,23 +193,23 @@ class Jackson3DependenciesTest implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencyManagement>
-                               <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson</groupId>
-                                     <artifactId>jackson-bom</artifactId>
-                                     <version>%s</version>
-                                     <scope>import</scope>
-                                     <type>pom</type>
-                                 </dependency>
-                               </dependencies>
-                             </dependencyManagement>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencyManagement>
+                        <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson</groupId>
+                              <artifactId>jackson-bom</artifactId>
+                              <version>%s</version>
+                              <scope>import</scope>
+                              <type>pom</type>
+                          </dependency>
+                        </dependencies>
+                      </dependencyManagement>
+                  </project>
                   """.formatted(jacksonVersion);
             })
           )
@@ -240,19 +241,19 @@ class Jackson3DependenciesTest implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.core</groupId>
-                                     <artifactId>jackson-databind</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson.core</groupId>
+                              <artifactId>jackson-databind</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
                   """.formatted(jacksonVersion);
             })
           )
@@ -284,6 +285,50 @@ class Jackson3DependenciesTest implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson.core</groupId>
+                              <artifactId>jackson-databind</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """.formatted(jacksonVersion);
+            })
+          )
+        );
+    }
+
+    @Test
+    void jacksonDatatypeJsr310() {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.datatype</groupId>
+                          <artifactId>jackson-datatype-jsr310</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                String jacksonVersion = versionMatcher.group(0);
+                return """
                          <project>
                              <modelVersion>4.0.0</modelVersion>
                              <groupId>org.example</groupId>
@@ -303,8 +348,9 @@ class Jackson3DependenciesTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-jackson/issues/37")
     @Test
-    void jacksonDatatypeJsr310() {
+    void noDuplicateJacksonDatabindDependencies() {
         rewriteRun(
           //language=xml
           pomXml(
@@ -315,6 +361,11 @@ class Jackson3DependenciesTest implements RewriteTest {
                   <artifactId>example</artifactId>
                   <version>1.0.0</version>
                   <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.core</groupId>
+                          <artifactId>jackson-databind</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
                       <dependency>
                           <groupId>com.fasterxml.jackson.datatype</groupId>
                           <artifactId>jackson-datatype-jsr310</artifactId>

--- a/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
@@ -188,23 +188,23 @@ class UpgradeJackson_2_3Test implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencyManagement>
-                               <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson</groupId>
-                                     <artifactId>jackson-bom</artifactId>
-                                     <version>%s</version>
-                                     <scope>pom</scope>
-                                     <type>import</type>
-                                 </dependency>
-                               </dependencies>
-                             </dependencyManagement>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencyManagement>
+                        <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson</groupId>
+                              <artifactId>jackson-bom</artifactId>
+                              <version>%s</version>
+                              <scope>pom</scope>
+                              <type>import</type>
+                          </dependency>
+                        </dependencies>
+                      </dependencyManagement>
+                  </project>
                   """.formatted(jacksonVersion);
             })),
           //language=java
@@ -287,19 +287,19 @@ class UpgradeJackson_2_3Test implements RewriteTest {
                 String annotationsVersion = annotationsVersionMatcher.group(0);
 
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.core</groupId>
-                                     <artifactId>jackson-databind</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson.core</groupId>
+                              <artifactId>jackson-databind</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
                   """.formatted(annotationsVersion);
             }))
         );


### PR DESCRIPTION
- Fixes #37

Improves on the current situation for Gradle in the most likely cases; there's an unlikely case of multiple remove modules without a dependency on jackson-databind that might still result in duplicate dependencies for Gradle, but that's accepted for now.