### PR TITLE
feat: Extend Jackson 2->3 recipe with more JsonNode method renames

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -262,15 +262,7 @@ tags:
 recipeList:
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_JsonGeneratorMethodRenames
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_JsonParserMethodRenames
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.fasterxml.jackson.databind.JsonNode elements()
-      newMethodName: values
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.fasterxml.jackson.databind.JsonNode isContainerNode()
-      newMethodName: isContainer
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: com.fasterxml.jackson.databind.JsonNode fields()
-      newMethodName: entries
+  - org.openrewrite.java.jackson.UpgradeJackson_2_3_JsonNodeMethodRenames
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -370,6 +362,44 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.core.JsonParser nextTextValue()
       newMethodName: nextStringValue
+
+# Based on https://github.com/FasterXML/jackson-future-ideas/wiki/JSTEP-3
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.jackson.UpgradeJackson_2_3_JsonNodeMethodRenames
+displayName: Rename Jackson 2.x methods to 3.x equivalents for JsonNode
+description: Rename JsonNode methods that were renamed in 3.x (e.g., `elements()` to `values()`, `fields()` to `entries()`).
+tags:
+  - jackson-3
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.JsonNode asText(..)
+      newMethodName: asString
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.JsonNode elements()
+      newMethodName: values
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.JsonNode fields()
+      newMethodName: properties
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.JsonNode fieldNames()
+      newMethodName: propertyNames
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.JsonNode findValuesAsText(..)
+      newMethodName: findValuesAsString
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.JsonNode isContainerNode()
+      newMethodName: isContainer
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.JsonNode isTextual()
+      newMethodName: isString
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.JsonNode textValue()
+      newMethodName: asString
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.JsonNode with(..)
+      newMethodName: withObject
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
@@ -366,4 +366,49 @@ class Jackson3MethodRenamesTest implements RewriteTest {
         );
     }
 
+    @Test
+    void jsonNodeMethods() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.JsonNode;
+              import java.util.List;
+
+              class Test {
+                  void test(JsonNode node) {
+                      String text = node.asText();
+                      var elements = node.elements();
+                      var fields = node.fields();
+                      var names = node.fieldNames();
+                      List<String> textValues = node.findValuesAsText("mango");
+                      boolean isContainer = node.isContainerNode();
+                      boolean isString = node.isTextual();
+                      boolean textValue = node.textValue();
+                      var modifiedNode = node.with("pineapple");
+                  }
+              }
+              """,
+            """
+              import tools.jackson.databind.JsonNode;
+              import java.util.List;
+
+              class Test {
+                  void test(JsonNode node) {
+                      String text = node.asString();
+                      var elements = node.values();
+                      var fields = node.properties();
+                      var names = node.propertyNames();
+                      List<String> textValues = node.findValuesAsString("mango");
+                      boolean isContainer = node.isContainer();
+                      boolean isString = node.isString();
+                      boolean textValue = node.asString();
+                      var modifiedNode = node.withObject("pineapple");
+                  }
+              }
+              """
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## What's changed?

* Add missing `JsonNode` method renames
* Extend tests to cover new additions to the recipe

## What's your motivation?

- Fixes gh-42

## Anything in particular you'd like reviewers to focus on?

No

## Anyone you would like to review specifically?

@timtebeek 

## Have you considered any alternatives or workarounds?

Yes, I could create my custom recipe or perform the changes manually.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
