### PR TITLE
feat: When Jackson 2->3, remove duplicates in Gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,9 +23,12 @@ dependencies {
         exclude("io.github.eisop","dataflow-errorprone")
     }
 
+    testImplementation("org.openrewrite:rewrite-gradle")
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.openrewrite:rewrite-maven")
+    testImplementation("org.openrewrite.gradle.tooling:model:${rewriteVersion}")
 
+    testRuntimeOnly(gradleApi())
     testRuntimeOnly("org.openrewrite:rewrite-java-21")
     testRuntimeOnly("org.codehaus.jackson:jackson-core-asl:latest.release")
     testRuntimeOnly("org.codehaus.jackson:jackson-mapper-asl:latest.release")

--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -146,7 +146,7 @@ tags:
   - jackson-3
 preconditions:
   # When jackson-databind is present, we can remove these dependencies
-  - org.openrewrite.maven.search.FindDependency:
+  - org.openrewrite.java.dependencies.FindDependency:
       groupId: com.fasterxml.jackson.core
       artifactId: jackson-databind
 recipeList:


### PR DESCRIPTION
## What's changed?

* Update the org.openrewrite.java.jackson.UpgradeJackson_2_3_RemoveModules recipe to check both Maven and Gradle dependencies.
* Add tests for the Gradle scenario. Since there wasn't a Gradle setup yet, I have configured it in the project.

## What's your motivation?

- Fixes gh-45

## Anything in particular you'd like reviewers to focus on?

Setup for running Rewrite Gradle tests.

## Anyone you would like to review specifically?

@timtebeek 

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
