### PR TITLE
Use wildcards to convert all artifacts under dataformat and module

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -81,6 +81,24 @@ recipeList:
       newArtifactId: jackson-module-kotlin
       newVersion: 3.0.x
   - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.module
+      oldArtifactId: jackson-module-scala_2.12
+      newGroupId: tools.jackson.module
+      newArtifactId: jackson-module-scala_2.12
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.module
+      oldArtifactId: jackson-module-scala_2.13
+      newGroupId: tools.jackson.module
+      newArtifactId: jackson-module-scala_2.13
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.module
+      oldArtifactId: jackson-module-scala_3
+      newGroupId: tools.jackson.module
+      newArtifactId: jackson-module-scala_3
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.dataformat
       oldArtifactId: jackson-dataformat-yaml
       newGroupId: tools.jackson.dataformat

--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -76,69 +76,13 @@ recipeList:
       newVersion: 3.0.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
-      oldArtifactId: jackson-module-kotlin
+      oldArtifactId: "*"
       newGroupId: tools.jackson.module
-      newArtifactId: jackson-module-kotlin
-      newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: com.fasterxml.jackson.module
-      oldArtifactId: jackson-module-scala_2.12
-      newGroupId: tools.jackson.module
-      newArtifactId: jackson-module-scala_2.12
-      newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: com.fasterxml.jackson.module
-      oldArtifactId: jackson-module-scala_2.13
-      newGroupId: tools.jackson.module
-      newArtifactId: jackson-module-scala_2.13
-      newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: com.fasterxml.jackson.module
-      oldArtifactId: jackson-module-scala_3
-      newGroupId: tools.jackson.module
-      newArtifactId: jackson-module-scala_3
       newVersion: 3.0.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.dataformat
-      oldArtifactId: jackson-dataformat-yaml
+      oldArtifactId: "*"
       newGroupId: tools.jackson.dataformat
-      newArtifactId: jackson-dataformat-yaml
-      newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: com.fasterxml.jackson.dataformat
-      oldArtifactId: jackson-dataformat-xml
-      newGroupId: tools.jackson.dataformat
-      newArtifactId: jackson-dataformat-xml
-      newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: com.fasterxml.jackson.dataformat
-      oldArtifactId: jackson-dataformat-csv
-      newGroupId: tools.jackson.dataformat
-      newArtifactId: jackson-dataformat-csv
-      newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: com.fasterxml.jackson.dataformat
-      oldArtifactId: jackson-dataformat-cbor
-      newGroupId: tools.jackson.dataformat
-      newArtifactId: jackson-dataformat-cbor
-      newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: com.fasterxml.jackson.dataformat
-      oldArtifactId: jackson-dataformat-avro
-      newGroupId: tools.jackson.dataformat
-      newArtifactId: jackson-dataformat-avro
-      newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: com.fasterxml.jackson.dataformat
-      oldArtifactId: jackson-dataformat-smile
-      newGroupId: tools.jackson.dataformat
-      newArtifactId: jackson-dataformat-smile
-      newVersion: 3.0.x
-  - org.openrewrite.java.dependencies.ChangeDependency:
-      oldGroupId: com.fasterxml.jackson.dataformat
-      oldArtifactId: jackson-dataformat-ion
-      newGroupId: tools.jackson.dataformat
-      newArtifactId: jackson-dataformat-ion
       newVersion: 3.0.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.datatype

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
@@ -99,7 +99,7 @@ class Jackson3DependenciesTest implements RewriteTest {
               </project>
               """,
             spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
@@ -143,7 +143,7 @@ class Jackson3DependenciesTest implements RewriteTest {
               </project>
               """,
             spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
@@ -187,7 +187,7 @@ class Jackson3DependenciesTest implements RewriteTest {
               </project>
               """,
             spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
@@ -231,26 +231,11 @@ class Jackson3DependenciesTest implements RewriteTest {
                   </dependencies>
               </project>
               """.formatted(artifactSuffix),
-            spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
-                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
-                String jacksonVersion = versionMatcher.group(0);
-                return """
-                  <project>
-                      <modelVersion>4.0.0</modelVersion>
-                      <groupId>org.example</groupId>
-                      <artifactId>example</artifactId>
-                      <version>1.0.0</version>
-                      <dependencies>
-                          <dependency>
-                              <groupId>tools.jackson.module</groupId>
-                              <artifactId>jackson-module-scala%s</artifactId>
-                              <version>%s</version>
-                          </dependency>
-                      </dependencies>
-                  </project>
-                  """.formatted(artifactSuffix, jacksonVersion);
-            })
+            spec -> spec.after(pom -> assertThat(pom)
+              .doesNotContain(">com.fasterxml.jackson.module<")
+              .contains(">tools.jackson.module<")
+              .containsPattern("3\\.\\d+\\.\\d+")
+              .actual())
           )
         );
     }
@@ -280,7 +265,7 @@ class Jackson3DependenciesTest implements RewriteTest {
               </project>
               """,
             spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
@@ -328,7 +313,7 @@ class Jackson3DependenciesTest implements RewriteTest {
               </project>
               """,
             spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
@@ -372,7 +357,7 @@ class Jackson3DependenciesTest implements RewriteTest {
               </project>
               """,
             spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
@@ -416,7 +401,7 @@ class Jackson3DependenciesTest implements RewriteTest {
               </project>
               """,
             spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
@@ -466,7 +451,7 @@ class Jackson3DependenciesTest implements RewriteTest {
               </project>
               """,
             spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
@@ -510,7 +495,7 @@ class Jackson3DependenciesTest implements RewriteTest {
               }
               """,
             spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
@@ -553,7 +538,7 @@ class Jackson3DependenciesTest implements RewriteTest {
               </project>
               """.formatted(format),
             spec -> spec.after(pom -> {
-                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
@@ -103,19 +103,19 @@ class Jackson3DependenciesTest implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.core</groupId>
-                                     <artifactId>jackson-core</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson.core</groupId>
+                              <artifactId>jackson-core</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
                   """.formatted(jacksonVersion);
             })
           )
@@ -147,19 +147,19 @@ class Jackson3DependenciesTest implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.core</groupId>
-                                     <artifactId>jackson-databind</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson.core</groupId>
+                              <artifactId>jackson-databind</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
                   """.formatted(jacksonVersion);
             })
           )
@@ -191,19 +191,19 @@ class Jackson3DependenciesTest implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.module</groupId>
-                                     <artifactId>jackson-module-kotlin</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson.module</groupId>
+                              <artifactId>jackson-module-kotlin</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
                   """.formatted(jacksonVersion);
             })
           )
@@ -236,19 +236,19 @@ class Jackson3DependenciesTest implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.module</groupId>
-                                     <artifactId>jackson-module-scala%s</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson.module</groupId>
+                              <artifactId>jackson-module-scala%s</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
                   """.formatted(artifactSuffix, jacksonVersion);
             })
           )
@@ -420,19 +420,19 @@ class Jackson3DependenciesTest implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.core</groupId>
-                                     <artifactId>jackson-databind</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson.core</groupId>
+                              <artifactId>jackson-databind</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
                   """.formatted(jacksonVersion);
             })
           )
@@ -470,19 +470,19 @@ class Jackson3DependenciesTest implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.core</groupId>
-                                     <artifactId>jackson-databind</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson.core</groupId>
+                              <artifactId>jackson-databind</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
                   """.formatted(jacksonVersion);
             })
           )
@@ -557,19 +557,19 @@ class Jackson3DependenciesTest implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
                 return """
-                         <project>
-                             <modelVersion>4.0.0</modelVersion>
-                             <groupId>org.example</groupId>
-                             <artifactId>example</artifactId>
-                             <version>1.0.0</version>
-                             <dependencies>
-                                 <dependency>
-                                     <groupId>tools.jackson.dataformat</groupId>
-                                     <artifactId>jackson-dataformat-%s</artifactId>
-                                     <version>%s</version>
-                                 </dependency>
-                             </dependencies>
-                         </project>
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>tools.jackson.dataformat</groupId>
+                              <artifactId>jackson-dataformat-%s</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
                   """.formatted(format, jacksonVersion);
             })
           )

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
@@ -208,6 +208,51 @@ class Jackson3DependenciesTest implements RewriteTest {
         );
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"_2.12", "_2.13", "_3"})
+    void jacksonModuleScala(String artifactSuffix) {
+        rewriteRun(
+          //language=xml
+          pomXml(
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.module</groupId>
+                          <artifactId>jackson-module-scala%s</artifactId>
+                          <version>2.19.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """.formatted(artifactSuffix),
+            spec -> spec.after(pom -> {
+                Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+(-rc[\\d]*)?").matcher(pom);
+                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                String jacksonVersion = versionMatcher.group(0);
+                return """
+                         <project>
+                             <modelVersion>4.0.0</modelVersion>
+                             <groupId>org.example</groupId>
+                             <artifactId>example</artifactId>
+                             <version>1.0.0</version>
+                             <dependencies>
+                                 <dependency>
+                                     <groupId>tools.jackson.module</groupId>
+                                     <artifactId>jackson-module-scala%s</artifactId>
+                                     <version>%s</version>
+                                 </dependency>
+                             </dependencies>
+                         </project>
+                  """.formatted(artifactSuffix, jacksonVersion);
+            })
+          )
+        );
+    }
+
     @Test
     void jacksonBom() {
         rewriteRun(


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

support jackson-module-scala

This includes Scala 2.12, Scala 2.13, and Scala 3

## Any additional context

https://repo1.maven.org/maven2/tools/jackson/jackson-bom/3.0.2/jackson-bom-3.0.2.pom

## Similar work

jackson-module-kotlin https://github.com/openrewrite/rewrite-jackson/pull/44



### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
