### PR TITLE
feat: support removing redundant feature flags on MapperBuilder

### DIFF
--- a/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
@@ -414,6 +414,99 @@ class RemoveRedundantFeatureFlagsTest implements RewriteTest {
         );
     }
 
+
+
+    @Nested
+    class MapperBuilder {
+
+        @Test
+        void removeEnableSortPropertiesAlphabetically() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import com.fasterxml.jackson.databind.MapperFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      void configure() {
+                          JsonMapper.builder().enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY).build();
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.MapperFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      void configure() {
+                          JsonMapper.builder().build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void removeDisableFailOnUnknownProperties() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      void configure() {
+                          JsonMapper.builder().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).build();
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      void configure() {
+                          JsonMapper.builder().build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void removeConfigureWithTrueForEnabledByDefault() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import com.fasterxml.jackson.databind.MapperFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      void configure() {
+                          JsonMapper.builder().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true).build();
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.MapperFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      void configure() {
+                          JsonMapper.builder().build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
+
     @Nested
     class RemoveConfigProperty {
         @Test


### PR DESCRIPTION
## What's changed?
Redundant feature flags are also used with mapper builders, such as JsonMapper.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
