### PR TITLE
Fix NPE when type is null in RemoveBuiltInModuleRegistrations

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/RemoveBuiltInModuleRegistrations.java
+++ b/src/main/java/org/openrewrite/java/jackson/RemoveBuiltInModuleRegistrations.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.Arrays;
@@ -83,7 +84,8 @@ public class RemoveBuiltInModuleRegistrations extends Recipe {
                     @Override
                     public @Nullable J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                         J.VariableDeclarations mv = (J.VariableDeclarations) super.visitVariableDeclarations(multiVariable, ctx);
-                        if (BUILT_IN_MODULES.contains(TypeUtils.toString(mv.getType()))) {
+                        JavaType type = mv.getType();
+                        if (type != null && BUILT_IN_MODULES.contains(TypeUtils.toString(type))) {
                             return null;
                         }
                         return mv;
@@ -93,10 +95,12 @@ public class RemoveBuiltInModuleRegistrations extends Recipe {
                         if (expr instanceof J.NewClass) {
                             J.NewClass newClass = (J.NewClass) expr;
                             if (newClass.getClazz() != null) {
-                                return BUILT_IN_MODULES.contains(TypeUtils.toString(newClass.getClazz().getType()));
+                                JavaType type = newClass.getClazz().getType();
+                                return type != null && BUILT_IN_MODULES.contains(TypeUtils.toString(type));
                             }
                         }
-                        return BUILT_IN_MODULES.contains(TypeUtils.toString(expr.getType()));
+                        JavaType type = expr.getType();
+                        return type != null && BUILT_IN_MODULES.contains(TypeUtils.toString(type));
                     }
                 }
         );


### PR DESCRIPTION
## Problem

`RemoveBuiltInModuleRegistrations` throws an NPE when processing code with lambda parameters that have inferred types:

```
java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.JavaType.toString()" because "type" is null
    at org.openrewrite.java.tree.TypeUtils.toString(TypeUtils.java:1178)
    at org.openrewrite.java.jackson.RemoveBuiltInModuleRegistrations$1.visitVariableDeclarations(RemoveBuiltInModuleRegistrations.java:86)
```

The issue occurs because `J.VariableDeclarations.getType()` returns `@Nullable JavaType`, but the code passes it directly to `TypeUtils.toString()` which doesn't handle null.

## Solution

Add null checks before calling `TypeUtils.toString()` in all three places where types are retrieved.

An alternative considered was making `TypeUtils.toString()` null-safe by returning null for null input. However, this would just move the NPE to callers that don't expect a null return value (e.g., `TypeUtils.toString(type).equals(...)`). The caller is in the best position to decide how to handle null types - in this case, if the type is null, it's clearly not one of the built-in Jackson modules.