### PR TITLE
fix: Migrate Jackson com.fasterxml.jackson.(jaxrs,jakarta.rs,jr) dependencies

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -189,6 +189,21 @@ recipeList:
       oldArtifactId: jackson-datatype-*
       newGroupId: tools.jackson.datatype
       newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.jaxrs
+      oldArtifactId: "*"
+      newGroupId: tools.jackson.jaxrs
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.jakarta.rs
+      oldArtifactId: "*"
+      newGroupId: tools.jackson.jakarta.rs
+      newVersion: 3.0.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: com.fasterxml.jackson.jr
+      oldArtifactId: "*"
+      newGroupId: tools.jackson.jr
+      newVersion: 3.0.x
   # Retained for the case where two or more removed modules are present, without jackson-databind
   - org.openrewrite.maven.RemoveDuplicateDependencies
 

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
@@ -620,4 +620,100 @@ class Jackson3DependenciesTest implements RewriteTest {
           )
         );
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"jackson-jaxrs-base", "jackson-jaxrs-cbor-provider", "jackson-jaxrs-json-provider",
+      "jackson-jaxrs-smile-provider", "jackson-jaxrs-xml-provider", "jackson-jaxrs-yaml-provider"})
+    void jaxrsMigrated(String artifact) {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                          <artifactId>%s</artifactId>
+                          <version>2.20.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """.formatted(artifact),
+            spec -> spec.after(pom ->
+              assertThat(pom)
+                .doesNotContain(">com.fasterxml.jackson.jaxrs<")
+                .contains(">tools.jackson.jaxrs<")
+                .containsPattern("3\\.\\d+\\.\\d+")
+                .actual())
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"jackson-jakarta-rs-base", "jackson-jakarta-rs-cbor-provider", "jackson-jakarta-rs-json-provider",
+      "jackson-jakarta-rs-smile-provider", "jackson-jakarta-rs-xml-provider", "jackson-jakarta-rs-yaml-provider"})
+    void jakartaRsMigrated(String artifact) {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+                          <artifactId>%s</artifactId>
+                          <version>2.20.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """.formatted(artifact),
+            spec -> spec.after(pom ->
+              assertThat(pom)
+                .doesNotContain(">com.fasterxml.jackson.jakarta.rs<")
+                .contains(">tools.jackson.jakarta.rs<")
+                .containsPattern("3\\.\\d+\\.\\d+")
+                .actual())
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"jackson-jr-all", "jackson-jr-annotation-support", "jackson-jr-extension-javatime",
+      "jackson-jr-objects", "jackson-jr-retrofit2", "jackson-jr-stree"})
+    void jrMigrated(String artifact) {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.jr</groupId>
+                          <artifactId>%s</artifactId>
+                          <version>2.20.0</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """.formatted(artifact),
+            spec -> spec.after(pom ->
+              assertThat(pom)
+                .doesNotContain(">com.fasterxml.jackson.jr<")
+                .contains(">tools.jackson.jr<")
+                .containsPattern("3\\.\\d+\\.\\d+")
+                .actual())
+          )
+        );
+    }
 }


### PR DESCRIPTION
to tools.jackson.(jaxrs,jakarta.rs,jr)

## What's changed?
Migrate the following dependencies
* [com.fasterxml.jackson.jaxrs](https://github.com/FasterXML/jackson-bom/blob/2.20/pom.xml#L267-L297) -> [tools.jackson.jaxrs](https://github.com/FasterXML/jackson-bom/blob/3.x/pom.xml#L281-L311)
* [com.fasterxml.jackson.jakarta.rs](https://github.com/FasterXML/jackson-bom/blob/2.20/pom.xml#L299-L329) -> [tools.jackson.jakarta.rs](https://github.com/FasterXML/jackson-bom/blob/3.x/pom.xml#L313-L343)
* [com.fasterxml.jackson.jr](https://github.com/FasterXML/jackson-bom/blob/2.20/pom.xml#L331-L361) -> [tools.jackson.jr](https://github.com/FasterXML/jackson-bom/blob/3.x/pom.xml#L345-L375)

## What's your motivation?
This "should" complete all Jackson dependencies

## Anything in particular you'd like reviewers to focus on?
Would you like me to merge these tests and others in this test class to use a single test with something like `@MethodSource` so that there is even less code to maintain?

Example:
```java
@ParameterizedTest
@MethodSource("provideDependencyData")
void dependenciesMigrated(String groupId, String artifact, String expectedGroupId) {
...
}

static Stream<Arguments> provideDependencyData() {
    return Stream.of(
        Arguments.of("com.fasterxml.jackson.jaxrs", "jackson-jaxrs-base", "tools.jackson.jaxrs"),
...
        Arguments.of("com.fasterxml.jackson.jakarta.rs", "jackson-jakarta-rs-base", "tools.jackson.jakarta.rs"),
        Arguments.of("com.fasterxml.jackson.jakarta.rs", "jackson-jakarta-rs-cbor-provider", "tools.jackson.jakarta.rs"),
    );
}
```

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
