### PR TITLE
fix: correct language

### DIFF
--- a/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3DependenciesTest.java
@@ -39,8 +39,8 @@ class Jackson3DependenciesTest implements RewriteTest {
     @Test
     void jacksonAnnotations() {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -78,8 +78,8 @@ class Jackson3DependenciesTest implements RewriteTest {
     @Test
     void jacksonCore() {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -108,8 +108,8 @@ class Jackson3DependenciesTest implements RewriteTest {
     @Test
     void jacksonDatabind() {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -138,8 +138,8 @@ class Jackson3DependenciesTest implements RewriteTest {
     @Test
     void jacksonModuleKotlin() {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -169,8 +169,8 @@ class Jackson3DependenciesTest implements RewriteTest {
     @ValueSource(strings = {"_2.12", "_2.13", "_3"})
     void jacksonModuleScala(String artifactSuffix) {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -198,8 +198,8 @@ class Jackson3DependenciesTest implements RewriteTest {
     @Test
     void jacksonBom() {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -232,8 +232,8 @@ class Jackson3DependenciesTest implements RewriteTest {
     @Test
     void jacksonModuleParameterNames() {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -265,8 +265,8 @@ class Jackson3DependenciesTest implements RewriteTest {
     @ValueSource(strings = {"jackson-datatype-jdk8", "jackson-datatype-jsr310"})
     void jacksonDatatypeJdk8(String datatypeModule) {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -298,8 +298,8 @@ class Jackson3DependenciesTest implements RewriteTest {
     @Test
     void noDuplicateJacksonDatabindDependencies() {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -369,8 +369,8 @@ class Jackson3DependenciesTest implements RewriteTest {
     @ValueSource(strings = {"yaml", "xml", "csv", "cbor", "avro", "smile", "ion"})
     void jacksonDataformats(String format) {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>

--- a/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
@@ -41,8 +41,8 @@ class UpgradeJackson_2_3Test implements RewriteTest {
     @Test
     void jacksonUpgradeToVersion3() {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -88,6 +88,7 @@ class UpgradeJackson_2_3Test implements RewriteTest {
                 assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
 
+                //language=xml
                 return """
                   <project>
                       <modelVersion>4.0.0</modelVersion>
@@ -157,8 +158,8 @@ class UpgradeJackson_2_3Test implements RewriteTest {
     @Test
     void jacksonUpgradeToVersion3_jacksonBomOnly() {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
so that syntax highlighting does not show errors

## What's changed?
Placement of `//language=xml`

## What's your motivation?
Remove false positive errors shown in IDE

Before
<img width="1330" height="1288" alt="Screenshot 2025-12-24 at 3 45 11 PM" src="https://github.com/user-attachments/assets/16562085-36e1-4be6-b598-b6b5648cfb60" />

After
<img width="1336" height="1280" alt="Screenshot 2025-12-24 at 3 45 22 PM" src="https://github.com/user-attachments/assets/9175f611-d200-49af-a11b-00032a15bf43" />

## Anyone you would like to review specifically?
@timtebeek 

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
