### PR TITLE
Fix core exception package paths for StreamReadException and StreamWriteException

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -253,10 +253,10 @@ recipeList:
       newFullyQualifiedTypeName: tools.jackson.dataformat.ion.IonWriteFeature
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.core.JsonParseException
-      newFullyQualifiedTypeName: tools.jackson.core.StreamReadException
+      newFullyQualifiedTypeName: tools.jackson.core.exc.StreamReadException
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.core.JsonGenerationException
-      newFullyQualifiedTypeName: tools.jackson.core.StreamWriteException
+      newFullyQualifiedTypeName: tools.jackson.core.exc.StreamWriteException
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.core.JsonProcessingException
       newFullyQualifiedTypeName: tools.jackson.core.JacksonException

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.jackson;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -255,6 +256,42 @@ class Jackson3TypeChangesTest implements RewriteTest {
               class XmlThings {
                   public final XmlReadFeature readFeature = XmlReadFeature.EMPTY_ELEMENT_AS_NULL;
                   public final XmlWriteFeature writeFeature = XmlWriteFeature.WRITE_XML_DECLARATION;
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-jackson/issues/75")
+    @Test
+    void jsonParseException() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonGenerationException;
+              import com.fasterxml.jackson.core.JsonParseException;
+
+              class Test {
+                  void handle(JsonParseException e) {
+                      e.printStackTrace();
+                  }
+                  void handle(JsonGenerationException e) {
+                      e.printStackTrace();
+                  }
+              }
+              """,
+            """
+              import tools.jackson.core.exc.StreamReadException;
+              import tools.jackson.core.exc.StreamWriteException;
+
+              class Test {
+                  void handle(StreamReadException e) {
+                      e.printStackTrace();
+                  }
+                  void handle(StreamWriteException e) {
+                      e.printStackTrace();
+                  }
               }
               """
           )


### PR DESCRIPTION
## Summary
- Fix `StreamReadException` package path from `tools.jackson.core` to `tools.jackson.core.exc`
- Fix `StreamWriteException` package path from `tools.jackson.core` to `tools.jackson.core.exc`
- Add test coverage for `JsonParseException` → `StreamReadException` and `JsonGenerationException` → `StreamWriteException` type changes

- Closes #75

## Test plan
- [x] `./gradlew test --tests "*Jackson3TypeChangesTest*"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)