### PR TITLE
Handle `ObjectMapper.setSerializationInclusion()` in Jackson 3 migration

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
+++ b/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
@@ -75,6 +75,8 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
                             return result.getPadding().withSelect(JRightPadded.build(result.getSelect()).withAfter(mi.getPadding().getSelect().getAfter()));
                         }
                         if (OBJECT_MAPPER_SET_SERIALIZATION_INCLUSION_MATCHER.matches(mi)) {
+                            // Uses Jackson 2 classpath because the type is still com.fasterxml.jackson.databind.ObjectMapper
+                            // at this point; the package migration to tools.jackson happens later in UpgradeJackson_2_3_PackageChanges
                             J.MethodInvocation result = JavaTemplate
                                     .builder("#{any(com.fasterxml.jackson.databind.ObjectMapper)}.setDefaultPropertyInclusion(#{any(com.fasterxml.jackson.annotation.JsonInclude.Include)})")
                                     .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx,

--- a/src/test/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfigurationTest.java
@@ -33,6 +33,33 @@ class UpdateSerializationInclusionConfigurationTest implements RewriteTest {
             "jackson-annotations-2", "jackson-core-2", "jackson-databind-2"));
     }
 
+    @Test
+    void updateSerializationInclusionOnObjectMapper() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import com.fasterxml.jackson.annotation.JsonInclude;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  private static ObjectMapper objectMapper = new ObjectMapper()
+                          .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+              }
+              """,
+            """
+              import com.fasterxml.jackson.annotation.JsonInclude;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  private static ObjectMapper objectMapper = new ObjectMapper()
+                          .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
+              }
+              """
+          )
+        );
+    }
+
     @DocumentExample
     @Test
     void updateSerializationInclusionOnBuilder() {


### PR DESCRIPTION
- Add support for migrating `ObjectMapper.setSerializationInclusion(Include.X)` → `ObjectMapper.setDefaultPropertyInclusion(Include.X)`, in addition to the existing `MapperBuilder.serializationInclusion()` handling
- Use `Preconditions.or()` to match both `ObjectMapper` and `MapperBuilder` variants
- Add test for `ObjectMapper` field initializer pattern (as seen in traderX)
