### PR TITLE
Revert "Handle `ObjectMapper.setSerializationInclusion()` in Jackson 3 migration"

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
+++ b/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
@@ -35,10 +35,9 @@ import static java.util.Collections.singleton;
 public class UpdateSerializationInclusionConfiguration extends Recipe {
 
     private static final MethodMatcher MAPPER_BUILDER_SERIALIZATION_INCLUSION_MATCHER = new MethodMatcher("com.fasterxml.jackson.databind..MapperBuilder serializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include)");
-    private static final MethodMatcher OBJECT_MAPPER_SET_SERIALIZATION_INCLUSION_MATCHER = new MethodMatcher("com.fasterxml.jackson.databind.ObjectMapper setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include)");
 
     @Getter
-    final String displayName = "Update configuration of serialization inclusion in `ObjectMapper` for Jackson 3";
+    final String displayName = "Update configuration of serialization inclusion in ObjectMapper for Jackson 3";
 
     @Getter
     final String description = "In Jackson 3, `mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)` is no longer supported " +
@@ -49,48 +48,28 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(
-                Preconditions.or(
-                        new UsesMethod<>(MAPPER_BUILDER_SERIALIZATION_INCLUSION_MATCHER),
-                        new UsesMethod<>(OBJECT_MAPPER_SET_SERIALIZATION_INCLUSION_MATCHER)
-                ),
-                new JavaIsoVisitor<ExecutionContext>() {
-                    @Override
-                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                        J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
-                        if (MAPPER_BUILDER_SERIALIZATION_INCLUSION_MATCHER.matches(mi)) {
-                            J.MethodInvocation result = JavaTemplate
-                                    .builder("#{any(tools.jackson.databind.json.JsonMapper$Builder)}.changeDefaultPropertyInclusion(incl -> incl" +
-                                            ".withContentInclusion(#{any(com.fasterxml.jackson.annotation.JsonInclude.Include)})" +
-                                            ".withValueInclusion(#{any(com.fasterxml.jackson.annotation.JsonInclude.Include)}))")
-                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx,
-                                            "jackson-annotations-2", "jackson-core-3", "jackson-databind-3"))
-                                    .build()
-                                    .apply(
-                                            getCursor(),
-                                            mi.getCoordinates().replace(),
-                                            mi.getSelect(),
-                                            mi.getArguments().get(0),
-                                            mi.getArguments().get(0));
-                            return result.getPadding().withSelect(JRightPadded.build(result.getSelect()).withAfter(mi.getPadding().getSelect().getAfter()));
-                        }
-                        if (OBJECT_MAPPER_SET_SERIALIZATION_INCLUSION_MATCHER.matches(mi)) {
-                            // Uses Jackson 2 classpath because the type is still com.fasterxml.jackson.databind.ObjectMapper
-                            // at this point; the package migration to tools.jackson happens later in UpgradeJackson_2_3_PackageChanges
-                            J.MethodInvocation result = JavaTemplate
-                                    .builder("#{any(com.fasterxml.jackson.databind.ObjectMapper)}.setDefaultPropertyInclusion(#{any(com.fasterxml.jackson.annotation.JsonInclude.Include)})")
-                                    .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx,
-                                            "jackson-annotations-2", "jackson-core-2", "jackson-databind-2"))
-                                    .build()
-                                    .apply(
-                                            getCursor(),
-                                            mi.getCoordinates().replace(),
-                                            mi.getSelect(),
-                                            mi.getArguments().get(0));
-                            return result.getPadding().withSelect(JRightPadded.build(result.getSelect()).withAfter(mi.getPadding().getSelect().getAfter()));
-                        }
-                        return mi;
-                    }
-                });
+        return Preconditions.check(new UsesMethod<>(MAPPER_BUILDER_SERIALIZATION_INCLUSION_MATCHER), new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation mi = super.visitMethodInvocation(method, ctx);
+                if (MAPPER_BUILDER_SERIALIZATION_INCLUSION_MATCHER.matches(mi)) {
+                    J.MethodInvocation result = JavaTemplate
+                            .builder("#{any(tools.jackson.databind.json.JsonMapper$Builder)}.changeDefaultPropertyInclusion(incl -> incl" +
+                                    ".withContentInclusion(#{any(com.fasterxml.jackson.annotation.JsonInclude.Include)})" +
+                                    ".withValueInclusion(#{any(com.fasterxml.jackson.annotation.JsonInclude.Include)}))")
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx,
+                                    "jackson-annotations-2", "jackson-core-3", "jackson-databind-3"))
+                            .build()
+                            .apply(
+                                    getCursor(),
+                                    mi.getCoordinates().replace(),
+                                    mi.getSelect(),
+                                    mi.getArguments().get(0),
+                                    mi.getArguments().get(0));
+                    return result.getPadding().withSelect(JRightPadded.build(result.getSelect()).withAfter(mi.getPadding().getSelect().getAfter()));
+                }
+                return mi;
+            }
+        });
     }
 }

--- a/src/test/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfigurationTest.java
@@ -33,33 +33,6 @@ class UpdateSerializationInclusionConfigurationTest implements RewriteTest {
             "jackson-annotations-2", "jackson-core-2", "jackson-databind-2"));
     }
 
-    @Test
-    void updateSerializationInclusionOnObjectMapper() {
-        rewriteRun(
-          // language=java
-          java(
-            """
-              import com.fasterxml.jackson.annotation.JsonInclude;
-              import com.fasterxml.jackson.databind.ObjectMapper;
-
-              class Test {
-                  private static ObjectMapper objectMapper = new ObjectMapper()
-                          .setSerializationInclusion(JsonInclude.Include.NON_NULL);
-              }
-              """,
-            """
-              import com.fasterxml.jackson.annotation.JsonInclude;
-              import com.fasterxml.jackson.databind.ObjectMapper;
-
-              class Test {
-                  private static ObjectMapper objectMapper = new ObjectMapper()
-                          .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
-              }
-              """
-          )
-        );
-    }
-
     @DocumentExample
     @Test
     void updateSerializationInclusionOnBuilder() {


### PR DESCRIPTION
- Reverts openrewrite/rewrite-jackson#79

These changes were causing the following exception in CLI and SaaS:
```
java.lang.IllegalArgumentException: Unable to find classpath resource dependencies beginning with: 'jackson-databind-2' in [develocity-gradle-plugin-3.19.2, gradle-base-services-6.1.1, gradle-core-api-6.1.1, gradle-language-groovy-6.1.1, gradle-language-java-6.1.1, gradle-logging-6.1.1, gradle-messaging-6.1.1, gradle-native-6.1.1, gradle-process-services-6.1.1, gradle-resources-6.1.1, gradle-testing-base-6.1.1, gradle-testing-jvm-6.1.1, httpclient5-5.1.4, httpcore5-5.1.5, jackson-annotations-2.19.2, jackson-core-2.19.2, spring-web-5.3.39]
  org.openrewrite.java.JavaParser.dependenciesFromResources(JavaParser.java:171)
  org.openrewrite.java.JavaParser$Builder.classpathFromResources(JavaParser.java:318)
  org.openrewrite.java.jackson.UpdateSerializationInclusionConfiguration$1.visitMethodInvocation(UpdateSerializationInclusionConfiguration.java:82)
  org.openrewrite.java.jackson.UpdateSerializationInclusionConfiguration$1.visitMethodInvocation(UpdateSerializationInclusionConfiguration.java:57)
  org.openrewrite.java.tree.J$MethodInvocation.acceptJava(J.java:4275)
  org.openrewrite.java.tree.J.accept(J.java:55)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:242)
  org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:309)
  org.openrewrite.java.JavaVisitor.visitRightPadded(JavaVisitor.java:1310)
  org.openrewrite.java.JavaVisitor.lambda$visitBlock$4(JavaVisitor.java:392)
  org.openrewrite.internal.ListUtils.map(ListUtils.java:245)
  org.openrewrite.internal.ListUtils.map(ListUtils.java:269)
  org.openrewrite.java.JavaVisitor.visitBlock(JavaVisitor.java:391)
  org.openrewrite.java.JavaIsoVisitor.visitBlock(JavaIsoVisitor.java:88)
  org.openrewrite.java.JavaIsoVisitor.visitBlock(JavaIsoVisitor.java:30)
  org.openrewrite.java.tree.J$Block.acceptJava(J.java:833)
```