### PR TITLE
`RemoveRedundantFeatureFlags` should retain `new ObjectMapper()` at start of chain

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlags.java
+++ b/src/main/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlags.java
@@ -109,8 +109,11 @@ public class RemoveRedundantFeatureFlags extends Recipe {
                     public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         if (shouldRemove(method)) {
                             maybeRemoveFeatureImport(method.getArguments().get(0));
-                            // If it's part of a chain, return the select; otherwise remove the statement
-                            return method.getSelect() instanceof J.MethodInvocation ? method.getSelect() : null;
+                            // If it's part of a chain (method call or new X()), return the select; otherwise remove the statement
+                            if (method.getSelect() instanceof J.MethodInvocation || method.getSelect() instanceof J.NewClass) {
+                                return method.getSelect().withPrefix(method.getPrefix());
+                            }
+                            return null;
                         }
                         return super.visitMethodInvocation(method, ctx);
                     }

--- a/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
@@ -400,6 +400,35 @@ class RemoveRedundantFeatureFlagsTest implements RewriteTest {
         );
     }
 
+    @Test
+    void removeConfigureChainedOnNewObjectMapper() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+              class Test {
+                  ObjectMapper configure() {
+                      return new ObjectMapper()
+                          .configure(WRITE_DATES_AS_TIMESTAMPS, false);
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  ObjectMapper configure() {
+                      return new ObjectMapper();
+                  }
+              }
+              """
+          )
+        );
+    }
+
 
 
     @Nested

--- a/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
@@ -407,7 +407,8 @@ class RemoveRedundantFeatureFlagsTest implements RewriteTest {
           java(
             """
               import com.fasterxml.jackson.databind.ObjectMapper;
-              import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 
               class Test {
                   ObjectMapper configure() {

--- a/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
@@ -407,8 +407,7 @@ class RemoveRedundantFeatureFlagsTest implements RewriteTest {
           java(
             """
               import com.fasterxml.jackson.databind.ObjectMapper;
-
-import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+              import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 
               class Test {
                   ObjectMapper configure() {


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
When configure/enable/disable is chained on new ObjectMapper(), the select is J.NewClass not J.MethodInvocation. Treat both as chain and return the select so the expression becomes 'new ObjectMapper()' instead of being removed (which left 'return;').

## What's your motivation?
Fixes an issue I discovered while running rewrite on my projects

## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?

## Have you considered any alternatives or workarounds?
I did not see any potential workaround to this aside from manually fixing the places it incorrectly removed code.

## Any additional context

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
