### PR TITLE
Fix Kotlin MapperBuilder changeDefaultPropertyInclusion matching

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
+++ b/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.JavaType;
 
 import java.util.Set;
 
@@ -34,7 +35,7 @@ import static java.util.Collections.singleton;
 
 public class UpdateSerializationInclusionConfiguration extends Recipe {
 
-    private static final MethodMatcher MAPPER_BUILDER_SERIALIZATION_INCLUSION_MATCHER = new MethodMatcher("com.fasterxml.jackson.databind..MapperBuilder serializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include)");
+    private static final MethodMatcher MAPPER_BUILDER_SERIALIZATION_INCLUSION_MATCHER = new MethodMatcher("com.fasterxml.jackson.databind..MapperBuilder serializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include)", true);
     private static final MethodMatcher OBJECT_MAPPER_SET_SERIALIZATION_INCLUSION_MATCHER = new MethodMatcher("com.fasterxml.jackson.databind.ObjectMapper setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include)");
 
     @Getter
@@ -72,7 +73,10 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
                                             mi.getSelect(),
                                             mi.getArguments().get(0),
                                             mi.getArguments().get(0));
-                            return result.getPadding().withSelect(JRightPadded.build(result.getSelect()).withAfter(mi.getPadding().getSelect().getAfter()));
+                            result = result.getPadding().withSelect(JRightPadded.build(result.getSelect()).withAfter(mi.getPadding().getSelect().getAfter()));
+                            // Fix lambda parameter type for Kotlin AST compatibility
+                            result = fixLambdaParameterType(result);
+                            return result;
                         }
                         if (OBJECT_MAPPER_SET_SERIALIZATION_INCLUSION_MATCHER.matches(mi)) {
                             // Simple rename from setSerializationInclusion to setDefaultPropertyInclusion;
@@ -84,6 +88,26 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
                             return mi;
                         }
                         return mi;
+                    }
+
+                    /**
+                     * The JavaTemplate-generated lambda has an untyped parameter which fails
+                     * Kotlin AST type validation. Walk the result to add the type to the
+                     * lambda parameter variable.
+                     */
+                    private J.MethodInvocation fixLambdaParameterType(J.MethodInvocation mi) {
+                        JavaType includeValueType = JavaType.ShallowClass.build("com.fasterxml.jackson.annotation.JsonInclude$Value");
+                        return (J.MethodInvocation) new JavaIsoVisitor<Integer>() {
+                            @Override
+                            public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Integer p) {
+                                J.VariableDeclarations.NamedVariable nv = super.visitVariable(variable, p);
+                                if ("incl".equals(nv.getSimpleName())) {
+                                    nv = nv.withVariableType(new JavaType.Variable(null, 0, "incl", includeValueType, includeValueType, null));
+                                    nv = nv.withName(nv.getName().withType(includeValueType));
+                                }
+                                return nv;
+                            }
+                        }.visitNonNull(mi, 0);
                     }
                 });
     }

--- a/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
+++ b/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
@@ -46,7 +46,7 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
             "and should be replaced by `changeDefaultPropertyInclusion()` for both `valueInclusion` and `contentInclusion`.";
 
     @Getter
-    final Set<String> tags = singleton( "jackson-3" );
+    final Set<String> tags = singleton("jackson-3");
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -74,9 +74,7 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
                                             mi.getArguments().get(0),
                                             mi.getArguments().get(0));
                             result = result.getPadding().withSelect(JRightPadded.build(result.getSelect()).withAfter(mi.getPadding().getSelect().getAfter()));
-                            // Fix lambda parameter type for Kotlin AST compatibility
-                            result = fixLambdaParameterType(result);
-                            return result;
+                            return fixLambdaParameterType(result);
                         }
                         if (OBJECT_MAPPER_SET_SERIALIZATION_INCLUSION_MATCHER.matches(mi)) {
                             // Simple rename from setSerializationInclusion to setDefaultPropertyInclusion;
@@ -102,8 +100,9 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
                             public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Integer p) {
                                 J.VariableDeclarations.NamedVariable nv = super.visitVariable(variable, p);
                                 if ("incl".equals(nv.getSimpleName())) {
-                                    nv = nv.withVariableType(new JavaType.Variable(null, 0, "incl", includeValueType, includeValueType, null));
-                                    nv = nv.withName(nv.getName().withType(includeValueType));
+                                    return nv
+                                            .withName(nv.getName().withType(includeValueType))
+                                            .withVariableType(new JavaType.Variable(null, 0, "incl", includeValueType, includeValueType, null));
                                 }
                                 return nv;
                             }

--- a/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
+++ b/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
@@ -75,8 +75,7 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
                                             mi.getArguments().get(0),
                                             mi.getArguments().get(0));
                             result = result.getPadding().withSelect(JRightPadded.build(result.getSelect()).withAfter(mi.getPadding().getSelect().getAfter()));
-                            result = fixLambdaParameterType(result);
-                            return fixLambdaBodySpacing(result);
+                            return fixKotlinLambdaParameterTypeAndBodySpacing(result);
                         }
                         if (OBJECT_MAPPER_SET_SERIALIZATION_INCLUSION_MATCHER.matches(mi)) {
                             // Simple rename from setSerializationInclusion to setDefaultPropertyInclusion;
@@ -90,13 +89,14 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
                         return mi;
                     }
 
-                    /**
-                     * The JavaTemplate-generated lambda body loses its leading space
-                     * when rendered to Kotlin. Walk the result to ensure the lambda
-                     * body has a single space prefix.
-                     */
-                    private J.MethodInvocation fixLambdaBodySpacing(J.MethodInvocation mi) {
+                    private J.MethodInvocation fixKotlinLambdaParameterTypeAndBodySpacing(J.MethodInvocation mi) {
+                        JavaType includeValueType = JavaType.ShallowClass.build("com.fasterxml.jackson.annotation.JsonInclude$Value");
                         return (J.MethodInvocation) new JavaIsoVisitor<Integer>() {
+                            /**
+                             * The JavaTemplate-generated lambda body loses its leading space
+                             * when rendered to Kotlin. Walk the result to ensure the lambda
+                             * body has a single space prefix.
+                             */
                             @Override
                             public J.Lambda visitLambda(J.Lambda lambda, Integer p) {
                                 J.Lambda l = super.visitLambda(lambda, p);
@@ -105,17 +105,12 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
                                 }
                                 return l;
                             }
-                        }.visitNonNull(mi, 0);
-                    }
 
-                    /**
-                     * The JavaTemplate-generated lambda has an untyped parameter which fails
-                     * Kotlin AST type validation. Walk the result to add the type to the
-                     * lambda parameter variable.
-                     */
-                    private J.MethodInvocation fixLambdaParameterType(J.MethodInvocation mi) {
-                        JavaType includeValueType = JavaType.ShallowClass.build("com.fasterxml.jackson.annotation.JsonInclude$Value");
-                        return (J.MethodInvocation) new JavaIsoVisitor<Integer>() {
+                            /**
+                             * The JavaTemplate-generated lambda has an untyped parameter which fails
+                             * Kotlin AST type validation. Walk the result to add the type to the
+                             * lambda parameter variable.
+                             */
                             @Override
                             public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Integer p) {
                                 J.VariableDeclarations.NamedVariable nv = super.visitVariable(variable, p);

--- a/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
+++ b/src/main/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfiguration.java
@@ -28,6 +28,7 @@ import org.openrewrite.java.search.UsesMethod;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
 
 import java.util.Set;
 
@@ -74,7 +75,8 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
                                             mi.getArguments().get(0),
                                             mi.getArguments().get(0));
                             result = result.getPadding().withSelect(JRightPadded.build(result.getSelect()).withAfter(mi.getPadding().getSelect().getAfter()));
-                            return fixLambdaParameterType(result);
+                            result = fixLambdaParameterType(result);
+                            return fixLambdaBodySpacing(result);
                         }
                         if (OBJECT_MAPPER_SET_SERIALIZATION_INCLUSION_MATCHER.matches(mi)) {
                             // Simple rename from setSerializationInclusion to setDefaultPropertyInclusion;
@@ -86,6 +88,24 @@ public class UpdateSerializationInclusionConfiguration extends Recipe {
                             return mi;
                         }
                         return mi;
+                    }
+
+                    /**
+                     * The JavaTemplate-generated lambda body loses its leading space
+                     * when rendered to Kotlin. Walk the result to ensure the lambda
+                     * body has a single space prefix.
+                     */
+                    private J.MethodInvocation fixLambdaBodySpacing(J.MethodInvocation mi) {
+                        return (J.MethodInvocation) new JavaIsoVisitor<Integer>() {
+                            @Override
+                            public J.Lambda visitLambda(J.Lambda lambda, Integer p) {
+                                J.Lambda l = super.visitLambda(lambda, p);
+                                if (l.getBody().getPrefix().isEmpty()) {
+                                    return l.withBody(l.getBody().withPrefix(Space.SINGLE_SPACE));
+                                }
+                                return l;
+                            }
+                        }.visitNonNull(mi, 0);
                     }
 
                     /**

--- a/src/test/java/org/openrewrite/java/jackson/KotlinUpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/java/jackson/KotlinUpgradeJackson_2_3Test.java
@@ -116,4 +116,34 @@ class KotlinUpgradeJackson_2_3Test implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void updateSerializationInclusionOnBuilder() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateSerializationInclusionConfiguration()),
+          //language=kotlin
+          kotlin(
+            """
+              import com.fasterxml.jackson.annotation.JsonInclude
+              import com.fasterxml.jackson.databind.json.JsonMapper
+
+              fun configure(): JsonMapper {
+                  return JsonMapper.builder()
+                      .serializationInclusion(JsonInclude.Include.NON_NULL)
+                      .build()
+              }
+              """,
+            """
+              import com.fasterxml.jackson.annotation.JsonInclude
+              import com.fasterxml.jackson.databind.json.JsonMapper
+
+              fun configure(): JsonMapper {
+                  return JsonMapper.builder()
+                      .changeDefaultPropertyInclusion({ incl ->incl.withContentInclusion(JsonInclude.Include.NON_NULL).withValueInclusion(JsonInclude.Include.NON_NULL)})
+                      .build()
+              }
+              """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/java/jackson/KotlinUpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/java/jackson/KotlinUpgradeJackson_2_3Test.java
@@ -139,7 +139,7 @@ class KotlinUpgradeJackson_2_3Test implements RewriteTest {
 
               fun configure(): JsonMapper {
                   return JsonMapper.builder()
-                      .changeDefaultPropertyInclusion({ incl ->incl.withContentInclusion(JsonInclude.Include.NON_NULL).withValueInclusion(JsonInclude.Include.NON_NULL)})
+                      .changeDefaultPropertyInclusion({ incl -> incl.withContentInclusion(JsonInclude.Include.NON_NULL).withValueInclusion(JsonInclude.Include.NON_NULL)})
                       .build()
               }
               """


### PR DESCRIPTION
## Summary

- Enable `matchOverrides` on the MapperBuilder `MethodMatcher` so `serializationInclusion` is matched when Kotlin resolves the declaring type as `JsonMapper$Builder` instead of `MapperBuilder`
- Fix lambda parameter type info for Kotlin AST compatibility
- Add Kotlin test for the MapperBuilder `serializationInclusion` → `changeDefaultPropertyInclusion` transformation

## Problem

The `UpdateSerializationInclusionConfiguration` recipe's MapperBuilder path silently skipped Kotlin source files. The Kotlin parser resolves `serializationInclusion()` declaring type as `JsonMapper$Builder` (concrete subclass), while the Java parser resolves it as `MapperBuilder` (where the method is declared). The `MethodMatcher` pattern `..MapperBuilder` matched by name only and didn't find `JsonMapper$Builder`.

Additionally, the `JavaTemplate`-generated lambda parameter lacked type info, which fails Kotlin AST type validation.

## Solution

1. Added `matchOverrides=true` to the `MethodMatcher` constructor, enabling subclass type matching
2. Added a post-processing step that sets `JsonInclude$Value` type on the lambda parameter variable

## Test plan

- [x] New Kotlin test `updateSerializationInclusionOnBuilder` passes
- [x] Existing Java tests pass unchanged
- [x] Existing Kotlin tests pass unchanged

- Fixes openrewrite/rewrite-jackson#89