### PR TITLE
Test double-brace initialization in UpdateSerializationInclusionConfiguration

### DIFF
--- a/src/test/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfigurationTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/UpdateSerializationInclusionConfigurationTest.java
@@ -68,6 +68,39 @@ class UpdateSerializationInclusionConfigurationTest implements RewriteTest {
     }
 
     @Test
+    void doubleBraceInitializationOnObjectMapper() {
+        rewriteRun(
+          // language=java
+          java(
+            """
+              import com.fasterxml.jackson.annotation.JsonInclude;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void foo(Object dummyReq) throws Exception {
+                      var paramRequestString = new ObjectMapper() {{
+                          setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
+                      }}.writeValueAsString(dummyReq);
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.annotation.JsonInclude;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void foo(Object dummyReq) throws Exception {
+                      var paramRequestString = new ObjectMapper() {{
+                          setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT);
+                      }}.writeValueAsString(dummyReq);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void updateSerializationInclusionOnObjectMapper() {
         rewriteRun(
           // language=java


### PR DESCRIPTION
- Add test case for issue #94 where setSerializationInclusion() is called with an implicit receiver inside a double-brace initializer block. The test verifies the recipe correctly handles this pattern and renames the method to setDefaultPropertyInclusion without crashing.
- closes #94