### PR TITLE
Fix Duplicate key error in SimplifyJacksonExceptionCatch

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/SimplifyJacksonExceptionCatch.java
+++ b/src/main/java/org/openrewrite/java/jackson/SimplifyJacksonExceptionCatch.java
@@ -24,6 +24,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JRightPadded;
 import org.openrewrite.java.tree.NameTree;
 import org.openrewrite.java.tree.TypeUtils;
 
@@ -61,14 +62,16 @@ public class SimplifyJacksonExceptionCatch extends Recipe {
                             return mc;
                         }
 
-                        List<NameTree> filtered = ListUtils.filter(mc.getAlternatives(), nt -> {
-                            if (TypeUtils.isAssignableTo(JACKSON_RUNTIME_EXCEPTION, nt.getType())) {
-                                maybeRemoveImport(TypeUtils.asFullyQualified(nt.getType()));
+                        List<JRightPadded<NameTree>> filtered = ListUtils.filter(mc.getPadding().getAlternatives(), rp -> {
+                            if (TypeUtils.isAssignableTo(JACKSON_RUNTIME_EXCEPTION, rp.getElement().getType())) {
+                                maybeRemoveImport(TypeUtils.asFullyQualified(rp.getElement().getType()));
                                 return false;
                             }
                             return true;
                         });
-                        return mc.withAlternatives(ListUtils.mapFirst(filtered, first -> first.withPrefix(mc.getAlternatives().get(0).getPrefix())));
+                        return mc.getPadding().withAlternatives(
+                                ListUtils.mapFirst(filtered, first -> first.withElement(
+                                        first.getElement().withPrefix(mc.getAlternatives().get(0).getPrefix()))));
                     }
                 }
         );

--- a/src/test/java/org/openrewrite/java/jackson/SimplifyJacksonExceptionCatchTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/SimplifyJacksonExceptionCatchTest.java
@@ -188,6 +188,55 @@ class SimplifyJacksonExceptionCatchTest implements RewriteTest {
     }
 
     @Test
+    void composedWithIOExceptionToJacksonExceptionOnMultiCatch() {
+        rewriteRun(
+          spec -> spec.recipes(
+            new IOExceptionToJacksonException(),
+            new SimplifyJacksonExceptionCatch()
+          ).expectedCyclesThatMakeChanges(2)
+           .parser(JavaParser.fromJavaVersion().classpathFromResources(new InMemoryExecutionContext(),
+            "jackson-core-2", "jackson-databind-2",
+            "jackson-core-3", "jackson-databind-3")),
+          java(
+            """
+              import java.io.FileInputStream;
+              import java.io.IOException;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void readAndDeserialize() {
+                      ObjectMapper mapper = new ObjectMapper();
+                      try {
+                          byte[] data = new FileInputStream("data.json").readAllBytes();
+                          mapper.readValue(data, String.class);
+                      } catch (IOException | RuntimeException e) {
+                          throw new RuntimeException(e);
+                      }
+                  }
+              }
+              """,
+            """
+              import java.io.FileInputStream;
+              import java.io.IOException;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void readAndDeserialize() {
+                      ObjectMapper mapper = new ObjectMapper();
+                      try {
+                          byte[] data = new FileInputStream("data.json").readAllBytes();
+                          mapper.readValue(data, String.class);
+                      } catch ( IOException | RuntimeException e) {
+                          throw new RuntimeException(e);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void noChangeWhenNoJacksonException() {
         rewriteRun(
           java(


### PR DESCRIPTION
Fix IllegalStateException: Duplicate key that occurred when SimplifyJacksonExceptionCatch processed certain multi-catch blocks.

The root cause was using `mc.withAlternatives(List<NameTree>)` which internally calls `JRightPadded.withElements` with `Collectors.toMap`, causing "Duplicate key" when matching against the original padded list.

Changed to work directly with padded alternatives (`mc.getPadding().getAlternatives()`) to avoid the problematic `withElements` call. All existing tests pass.