### PR TITLE
Fix duplicate key crash in SimplifyJacksonExceptionCatch

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/IOExceptionToJacksonException.java
+++ b/src/main/java/org/openrewrite/java/jackson/IOExceptionToJacksonException.java
@@ -120,7 +120,7 @@ public class IOExceptionToJacksonException extends Recipe {
                                 List<JRightPadded<NameTree>> newAlts = new ArrayList<>();
                                 for (JRightPadded<NameTree> rp : origMultiCatch.getPadding().getAlternatives()) {
                                     if (TypeUtils.isOfClassType(rp.getElement().getType(), IO_EXCEPTION)) {
-                                        newAlts.add(JRightPadded.build((NameTree) finalJacksonAlt.withPrefix(Space.SINGLE_SPACE)).withAfter(Space.SINGLE_SPACE));
+                                        newAlts.add(JRightPadded.build((NameTree) ((J) finalJacksonAlt.withId(Tree.randomId())).withPrefix(Space.SINGLE_SPACE)).withAfter(Space.SINGLE_SPACE));
                                     }
                                     newAlts.add(rp);
                                 }

--- a/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
@@ -269,6 +269,50 @@ class UpgradeJackson_2_3Test implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/1995")
+    @Test
+    void multiCatchWithRuntimeExceptionAndIOExceptionDoesNotCrash() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.FileInputStream;
+              import java.io.IOException;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void readAndDeserialize() {
+                      ObjectMapper mapper = new ObjectMapper();
+                      try {
+                          byte[] data = new FileInputStream("data.json").readAllBytes();
+                          mapper.readValue(data, String.class);
+                      } catch (RuntimeException | IOException e) {
+                          throw new RuntimeException(e);
+                      }
+                  }
+              }
+              """,
+            """
+              import java.io.FileInputStream;
+              import java.io.IOException;
+              import tools.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void readAndDeserialize() {
+                      ObjectMapper mapper = new ObjectMapper();
+                      try {
+                          byte[] data = new FileInputStream("data.json").readAllBytes();
+                          mapper.readValue(data, String.class);
+                      } catch (RuntimeException | IOException e) {
+                          throw new RuntimeException(e);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void jacksonUpgradeToVersion3_java8Only() {
         rewriteRun(


### PR DESCRIPTION
## Summary

- Fix `IllegalStateException: Duplicate key` crash when running `UpgradeJackson_2_3` on code with `catch (RuntimeException | IOException e)` and mixed Jackson/non-Jackson IO in the try block
- Add integration test reproducing the exact crash from the customer report

## Problem

When `IOExceptionToJacksonException` inserts a `JacksonException` alternative into an existing multi-catch, the new `NameTree` was derived from `ChangeType` and shared the same UUID as the original `IOException` `NameTree`. Both ended up in the alternatives list. When `SimplifyJacksonExceptionCatch` later called `mc.withAlternatives()`, `JRightPadded.withElements` built a `Map<UUID, ...>` from the old elements and hit `IllegalStateException: Duplicate key`.

## Solution

Assign a fresh UUID via `Tree.randomId()` to the inserted `JacksonException` `NameTree` in `IOExceptionToJacksonException.addJacksonExceptionCatch()`, ensuring all alternatives in the multi-catch have unique IDs.

## Test plan

- [x] Existing tests pass
- [x] New integration test reproduces the crash before fix and passes after

- Fixes moderneinc/customer-requests#1995