### PR TITLE
Add ChangeType for SimpleFilterProvider and SimpleBeanPropertyFilter

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -310,6 +310,12 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.databind.Module
       newFullyQualifiedTypeName: tools.jackson.databind.JacksonModule
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider
+      newFullyQualifiedTypeName: tools.jackson.databind.ser.std.SimpleFilterProvider
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter
+      newFullyQualifiedTypeName: tools.jackson.databind.ser.std.SimpleBeanPropertyFilter
 
 # Based on https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md
 

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
@@ -262,7 +262,6 @@ class Jackson3TypeChangesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/customer-requests/issues/2003")
     @Test
     void simpleFilterProvider() {
         rewriteRun(
@@ -286,7 +285,6 @@ class Jackson3TypeChangesTest implements RewriteTest {
         );
     }
 
-    @Issue("https://github.com/moderneinc/customer-requests/issues/2003")
     @Test
     void simpleBeanPropertyFilter() {
         rewriteRun(

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3TypeChangesTest.java
@@ -262,6 +262,54 @@ class Jackson3TypeChangesTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2003")
+    @Test
+    void simpleFilterProvider() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+
+              class Test {
+                  SimpleFilterProvider provider = new SimpleFilterProvider();
+              }
+              """,
+            """
+              import tools.jackson.databind.ser.std.SimpleFilterProvider;
+
+              class Test {
+                  SimpleFilterProvider provider = new SimpleFilterProvider();
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2003")
+    @Test
+    void simpleBeanPropertyFilter() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+
+              class Test {
+                  SimpleBeanPropertyFilter filter = SimpleBeanPropertyFilter.serializeAll();
+              }
+              """,
+            """
+              import tools.jackson.databind.ser.std.SimpleBeanPropertyFilter;
+
+              class Test {
+                  SimpleBeanPropertyFilter filter = SimpleBeanPropertyFilter.serializeAll();
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-jackson/issues/75")
     @Test
     void jsonParseException() {


### PR DESCRIPTION
## Summary

- Add `ChangeType` entries for `SimpleFilterProvider` and `SimpleBeanPropertyFilter` which moved from `ser.impl` to `ser.std` in Jackson 3.x
- Add tests verifying the correct package migration for both classes
- Fixes https://github.com/moderneinc/customer-requests/issues/2002

## Problem

After running the Jackson 2→3 migration recipe, code using `SimpleFilterProvider` fails to compile:
```
cannot find symbol:
symbol: class SimpleFilterProvider
location: package tools.jackson.databind.ser.impl
```

The blanket `ChangePackage` from `com.fasterxml.jackson.databind` to `tools.jackson.databind` correctly updates the top-level prefix but doesn't account for classes that also changed sub-packages. In Jackson 3.x, `SimpleFilterProvider` and `SimpleBeanPropertyFilter` moved from `ser.impl` to `ser.std` as part of [jackson-databind#4815](https://github.com/FasterXML/jackson-databind/pull/4815) (rename `SerializerProvider` as `SerializationContext`).

Jackson 3.x Javadoc:
- [`tools.jackson.databind.ser.std.SimpleFilterProvider`](https://javadoc.io/doc/tools.jackson.core/jackson-databind/latest/tools.jackson.databind/tools/jackson/databind/ser/std/SimpleFilterProvider.html)
- [`tools.jackson.databind.ser.std.SimpleBeanPropertyFilter`](https://javadoc.io/doc/tools.jackson.core/jackson-databind/latest/tools.jackson.databind/tools/jackson/databind/ser/std/SimpleBeanPropertyFilter.html)

## Solution

Add `ChangeType` entries to `UpgradeJackson_2_3_TypeChanges` (which runs before `PackageChanges`) to handle the sub-package relocation:
- `com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider` → `tools.jackson.databind.ser.std.SimpleFilterProvider`
- `com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter` → `tools.jackson.databind.ser.std.SimpleBeanPropertyFilter`

Since `ChangeType` runs first, the fully qualified type is updated before `ChangePackage` runs, avoiding a conflict.

## Test plan

- [x] New tests added for `SimpleFilterProvider` migration
- [x] New tests added for `SimpleBeanPropertyFilter` migration
- [x] Existing `Jackson3TypeChangesTest` tests still pass