### PR TITLE
Handle fully-qualified feature flag references in RemoveRedundantFeatureFlags

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlags.java
+++ b/src/main/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlags.java
@@ -154,6 +154,11 @@ public class RemoveRedundantFeatureFlags extends Recipe {
                                 String className = ((J.Identifier) fieldAccess.getTarget()).getSimpleName();
                                 String fieldName = fieldAccess.getName().getSimpleName();
                                 return className + "." + fieldName;
+                            } else if (fieldAccess.getTarget() instanceof J.FieldAccess) {
+                                // Handle fully-qualified access like com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS
+                                String className = ((J.FieldAccess) fieldAccess.getTarget()).getName().getSimpleName();
+                                String fieldName = fieldAccess.getName().getSimpleName();
+                                return className + "." + fieldName;
                             }
                         } else if (arg instanceof J.Identifier) {
                             // Handle static imports

--- a/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
@@ -282,6 +282,63 @@ class RemoveRedundantFeatureFlagsTest implements RewriteTest {
     }
 
     @Test
+    void removeDisableWriteDatesAsTimestamps() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.SerializationFeature;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void configure() {
+                      ObjectMapper mapper = new ObjectMapper();
+                      mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void configure() {
+                      ObjectMapper mapper = new ObjectMapper();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeDisableWriteDatesAsTimestampsFullyQualified() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void configure() {
+                      ObjectMapper mapper = new ObjectMapper();
+                      mapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void configure() {
+                      ObjectMapper mapper = new ObjectMapper();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removeConfigureWriteDatesAsTimestamps() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## Summary

- Fix `RemoveRedundantFeatureFlags` not handling fully-qualified constant references like `com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS`
- The `getFeatureNameFromArg` method only handled `J.Identifier` targets (simple imports) but not nested `J.FieldAccess` targets (fully-qualified access)
- Add tests for both `mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)` (import) and fully-qualified form

## Test plan

- [x] New test `removeDisableWriteDatesAsTimestamps` passes
- [x] New test `removeDisableWriteDatesAsTimestampsFullyQualified` passes
- [x] All existing `RemoveRedundantFeatureFlagsTest` tests still pass