### PR TITLE
Rename ObjectMapper methods for Jackson 3 migration

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/RemoveBuiltInModuleRegistrations.java
+++ b/src/main/java/org/openrewrite/java/jackson/RemoveBuiltInModuleRegistrations.java
@@ -40,6 +40,7 @@ public class RemoveBuiltInModuleRegistrations extends Recipe {
 
     private static final String OBJECT_MAPPER_TYPE = "com.fasterxml.jackson.databind.ObjectMapper";
     private static final MethodMatcher REGISTER_MODULE = new MethodMatcher(OBJECT_MAPPER_TYPE + " registerModule*(..)");
+    private static final MethodMatcher OBJECT_MAPPER_ADD_MODULE = new MethodMatcher(OBJECT_MAPPER_TYPE + " addModule*(..)");
     private static final String OBJECT_MAPPER_BUILDER_TYPE = "com.fasterxml.jackson.databind.cfg.MapperBuilder";
     private static final MethodMatcher ADD_MODULE = new MethodMatcher(OBJECT_MAPPER_BUILDER_TYPE + " addModule*(..)");
 
@@ -62,10 +63,10 @@ public class RemoveBuiltInModuleRegistrations extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(Preconditions.or(new UsesMethod<>(REGISTER_MODULE), new UsesMethod<>(ADD_MODULE)), new JavaVisitor<ExecutionContext>() {
+        return Preconditions.check(Preconditions.or(new UsesMethod<>(REGISTER_MODULE), new UsesMethod<>(OBJECT_MAPPER_ADD_MODULE), new UsesMethod<>(ADD_MODULE)), new JavaVisitor<ExecutionContext>() {
                     @Override
                     public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                        if ((REGISTER_MODULE.matches(method) || ADD_MODULE.matches(method)) &&
+                        if ((REGISTER_MODULE.matches(method) || OBJECT_MAPPER_ADD_MODULE.matches(method) || ADD_MODULE.matches(method)) &&
                                 method.getArguments().stream().anyMatch(this::isBuiltInModuleInstantiation)) {
                             for (String module : BUILT_IN_MODULES) {
                                 maybeRemoveImport(module);

--- a/src/main/java/org/openrewrite/java/jackson/RemoveBuiltInModuleRegistrations.java
+++ b/src/main/java/org/openrewrite/java/jackson/RemoveBuiltInModuleRegistrations.java
@@ -40,7 +40,6 @@ public class RemoveBuiltInModuleRegistrations extends Recipe {
 
     private static final String OBJECT_MAPPER_TYPE = "com.fasterxml.jackson.databind.ObjectMapper";
     private static final MethodMatcher REGISTER_MODULE = new MethodMatcher(OBJECT_MAPPER_TYPE + " registerModule*(..)");
-    private static final MethodMatcher OBJECT_MAPPER_ADD_MODULE = new MethodMatcher(OBJECT_MAPPER_TYPE + " addModule*(..)");
     private static final String OBJECT_MAPPER_BUILDER_TYPE = "com.fasterxml.jackson.databind.cfg.MapperBuilder";
     private static final MethodMatcher ADD_MODULE = new MethodMatcher(OBJECT_MAPPER_BUILDER_TYPE + " addModule*(..)");
 
@@ -63,10 +62,10 @@ public class RemoveBuiltInModuleRegistrations extends Recipe {
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return Preconditions.check(Preconditions.or(new UsesMethod<>(REGISTER_MODULE), new UsesMethod<>(OBJECT_MAPPER_ADD_MODULE), new UsesMethod<>(ADD_MODULE)), new JavaVisitor<ExecutionContext>() {
+        return Preconditions.check(Preconditions.or(new UsesMethod<>(REGISTER_MODULE), new UsesMethod<>(ADD_MODULE)), new JavaVisitor<ExecutionContext>() {
                     @Override
                     public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
-                        if ((REGISTER_MODULE.matches(method) || OBJECT_MAPPER_ADD_MODULE.matches(method) || ADD_MODULE.matches(method)) &&
+                        if ((REGISTER_MODULE.matches(method) || ADD_MODULE.matches(method)) &&
                                 method.getArguments().stream().anyMatch(this::isBuiltInModuleInstantiation)) {
                             for (String module : BUILT_IN_MODULES) {
                                 maybeRemoveImport(module);

--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -44,6 +44,7 @@ recipeList:
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_MethodRenames
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_RemoveRedundantFeatureFlags
   - org.openrewrite.java.jackson.RemoveBuiltInModuleRegistrations
+  - org.openrewrite.java.jackson.UpgradeJackson_2_3_ObjectMapperMethodRenames
   - org.openrewrite.java.jackson.UseModernDateTimeSerialization
   - org.openrewrite.java.jackson.ReplaceStreamWriteCapability
   - org.openrewrite.java.jackson.ReplaceJsonIgnoreWithJsonSetter
@@ -330,7 +331,6 @@ recipeList:
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_JsonGeneratorMethodRenames
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_JsonParserMethodRenames
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_JsonNodeMethodRenames
-  - org.openrewrite.java.jackson.UpgradeJackson_2_3_ObjectMapperMethodRenames
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.databind.type.TypeFactory defaultInstance()
       newMethodName: createDefaultInstance

--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -330,6 +330,7 @@ recipeList:
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_JsonGeneratorMethodRenames
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_JsonParserMethodRenames
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_JsonNodeMethodRenames
+  - org.openrewrite.java.jackson.UpgradeJackson_2_3_ObjectMapperMethodRenames
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.databind.type.TypeFactory defaultInstance()
       newMethodName: createDefaultInstance
@@ -570,3 +571,18 @@ recipeList:
       oldPackageName: com.fasterxml.jackson.datatype
       newPackageName: tools.jackson.datatype
       recursive: true
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.java.jackson.UpgradeJackson_2_3_ObjectMapperMethodRenames
+displayName: Rename Jackson 2.x methods to 3.x equivalents for ObjectMapper
+description: Rename ObjectMapper methods that were renamed in 3.x (e.g., `setDateFormat()` to `defaultDateFormat()`, `registerModule()` to `addModule()`).
+tags:
+  - jackson-3
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.ObjectMapper setDateFormat(..)
+      newMethodName: defaultDateFormat
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.ObjectMapper registerModule(..)
+      newMethodName: addModule

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
@@ -367,6 +367,64 @@ class Jackson3MethodRenamesTest implements RewriteTest {
     }
 
     @Test
+    void objectMapperSetDateFormat() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              import java.text.SimpleDateFormat;
+
+              class Test {
+                  void test(ObjectMapper mapper) {
+                      mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+                  }
+              }
+              """,
+            """
+              import tools.jackson.databind.ObjectMapper;
+              import java.text.SimpleDateFormat;
+
+              class Test {
+                  void test(ObjectMapper mapper) {
+                      mapper.defaultDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void objectMapperRegisterModule() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.Module;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+
+              class Test {
+                  void test(ObjectMapper mapper, Module module) {
+                      mapper.registerModule(module);
+                  }
+              }
+              """,
+            """
+              import tools.jackson.databind.ObjectMapper;
+              import tools.jackson.databind.JacksonModule;
+
+              class Test {
+                  void test(ObjectMapper mapper, JacksonModule module) {
+                      mapper.addModule(module);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void jsonNodeMethods() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## Summary

- Add `ChangeMethodName` recipes for `ObjectMapper.setDateFormat` → `defaultDateFormat` and `ObjectMapper.registerModule` → `addModule`
- Place the rename recipe after `RemoveBuiltInModuleRegistrations` in the chain so built-in module removal still matches `registerModule`

## Problem

Jackson 3 renamed several `ObjectMapper` methods. `setDateFormat` became `defaultDateFormat` and `registerModule` became `addModule`. The existing Jackson 2→3 migration recipe did not handle these renames.

## Solution

Add a new `UpgradeJackson_2_3_ObjectMapperMethodRenames` declarative recipe with two `ChangeMethodName` entries. It runs after `RemoveBuiltInModuleRegistrations` in the top-level recipe chain to avoid interfering with built-in module removal matching.

## Test plan

- [x] Existing tests pass
- [x] New tests added for `objectMapperSetDateFormat` and `objectMapperRegisterModule`

- Fixes moderneinc/customer-requests#2012 (recipe 4)