### PR TITLE
Fix chained method removal in RemoveBuiltInModuleRegistrations and RemoveRedundantFeatureFlags

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/RemoveBuiltInModuleRegistrations.java
+++ b/src/main/java/org/openrewrite/java/jackson/RemoveBuiltInModuleRegistrations.java
@@ -72,7 +72,8 @@ public class RemoveBuiltInModuleRegistrations extends Recipe {
                             }
                             // If it's part of a chain, return the select; otherwise remove the statement
                             if (method.getSelect() instanceof J.MethodInvocation || method.getSelect() instanceof J.NewClass) {
-                                return method.getSelect().withPrefix(method.getPrefix());
+                                J visited = visit(method.getSelect(), ctx);
+                                return visited != null ? visited.withPrefix(method.getPrefix()) : null;
                             }
                             return null;
                         }

--- a/src/main/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlags.java
+++ b/src/main/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlags.java
@@ -111,7 +111,8 @@ public class RemoveRedundantFeatureFlags extends Recipe {
                             maybeRemoveFeatureImport(method.getArguments().get(0));
                             // If it's part of a chain (method call or new X()), return the select; otherwise remove the statement
                             if (method.getSelect() instanceof J.MethodInvocation || method.getSelect() instanceof J.NewClass) {
-                                return method.getSelect().withPrefix(method.getPrefix());
+                                J visited = visit(method.getSelect(), ctx);
+                                return visited != null ? visited.withPrefix(method.getPrefix()) : null;
                             }
                             return null;
                         }

--- a/src/test/java/org/openrewrite/java/jackson/RemoveBuiltInModuleRegistrationsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/RemoveBuiltInModuleRegistrationsTest.java
@@ -373,6 +373,41 @@ class RemoveBuiltInModuleRegistrationsTest implements RewriteTest {
             );
         }
 
+        @Issue("https://github.com/openrewrite/rewrite-jackson/issues/105")
+        @Test
+        void removeMultipleChainedBuiltInModules() {
+            rewriteRun(
+              java(
+                // language=java
+                """
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+                  import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+                  class Test {
+                      void configure() {
+                          JsonMapper.builder()
+                          .addModule(new Jdk8Module())
+                          .addModule(new JavaTimeModule())
+                          .build();
+                      }
+                  }
+                  """,
+                // language=java
+                """
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      void configure() {
+                          JsonMapper.builder()
+                          .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
         @Test
         void removeParameterNamesModuleRegistration() {
             rewriteRun(

--- a/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
@@ -574,6 +574,37 @@ class RemoveRedundantFeatureFlagsTest implements RewriteTest {
               )
             );
         }
+        @Test
+        void removeMultipleChainedRedundantFlags() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import com.fasterxml.jackson.databind.MapperFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      void configure() {
+                          JsonMapper.builder()
+                              .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+                              .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+                              .build();
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      void configure() {
+                          JsonMapper.builder()
+                              .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary
- Fixes #105: `RemoveBuiltInModuleRegistrations` only removed one built-in module when multiple were chained (e.g., `.addModule(new Jdk8Module()).addModule(new JavaTimeModule())`). Now all are removed in a single pass.
- Applies the same fix to `RemoveRedundantFeatureFlags`, which had the identical bug with chained `.enable()`/`.disable()`/`.configure()` calls.

## Details
When the visitor matched a chained call and returned `method.getSelect()`, it skipped visiting the select expression, so inner chained matches were never processed. The fix calls `visit(method.getSelect(), ctx)` before returning, ensuring nested matches are recursively handled.

## Testing
- Added test for chained `.addModule()` calls on `JsonMapper.builder()` (issue #105 scenario)
- Added test for chained `.enable()`/`.configure()` calls on `JsonMapper.builder()`