### PR TITLE
Add all ObjectMapper setter-to-builder mappings

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -42,13 +42,62 @@ public class MigrateMapperSettersToBuilder extends Recipe {
 
     @RequiredArgsConstructor
     enum SetterToBuilderMapping {
-        SET_FILTER_PROVIDER("setFilterProvider", "filterProvider"),
-        ADD_MIX_IN("addMixIn", "addMixIn"),
-        SET_DATE_FORMAT("setDateFormat", "defaultDateFormat"),
-        ADD_HANDLER("addHandler", "addHandler"),
+        // Feature enable/disable/configure (covers all feature types via overloading)
+        CONFIGURE("configure", "configure"),
         DISABLE("disable", "disable"),
         ENABLE("enable", "enable"),
-        REGISTER_MODULE("registerModule", "addModule");
+
+        // Module registration
+        REGISTER_MODULE("registerModule", "addModule"),
+        REGISTER_MODULES("registerModules", "addModules"),
+        FIND_AND_REGISTER_MODULES("findAndRegisterModules", "findAndAddModules"),
+
+        // Mix-in & subtype registration
+        ADD_MIX_IN("addMixIn", "addMixIn"),
+        REGISTER_SUBTYPES("registerSubtypes", "registerSubtypes"),
+
+        // Deserialization problem handlers
+        ADD_HANDLER("addHandler", "addHandler"),
+        CLEAR_PROBLEM_HANDLERS("clearProblemHandlers", "clearProblemHandlers"),
+
+        // Default typing
+        ACTIVATE_DEFAULT_TYPING("activateDefaultTyping", "activateDefaultTyping"),
+        ACTIVATE_DEFAULT_TYPING_AS_PROPERTY("activateDefaultTypingAsProperty", "activateDefaultTypingAsProperty"),
+        DEACTIVATE_DEFAULT_TYPING("deactivateDefaultTyping", "deactivateDefaultTyping"),
+        SET_DEFAULT_TYPING("setDefaultTyping", "setDefaultTyping"),
+
+        // Serialization settings
+        SET_FILTER_PROVIDER("setFilterProvider", "filterProvider"),
+        SET_SERIALIZER_FACTORY("setSerializerFactory", "serializerFactory"),
+        SET_DEFAULT_PRETTY_PRINTER("setDefaultPrettyPrinter", "defaultPrettyPrinter"),
+
+        // Deserialization settings
+        SET_INJECTABLE_VALUES("setInjectableValues", "injectableValues"),
+        SET_NODE_FACTORY("setNodeFactory", "nodeFactory"),
+        SET_CONSTRUCTOR_DETECTOR("setConstructorDetector", "constructorDetector"),
+        SET_CACHE_PROVIDER("setCacheProvider", "cacheProvider"),
+
+        // Introspection & naming
+        SET_ANNOTATION_INTROSPECTOR("setAnnotationIntrospector", "annotationIntrospector"),
+        SET_TYPE_FACTORY("setTypeFactory", "typeFactory"),
+        SET_SUBTYPES_RESOLVER("setSubtypeResolver", "subtypeResolver"),
+        SET_VISIBILITY("setVisibility", "visibility"),
+        SET_HANDLER_INSTANTIATOR("setHandlerInstantiator", "handlerInstantiator"),
+        SET_PROPERTY_NAMING_STRATEGY("setPropertyNamingStrategy", "propertyNamingStrategy"),
+        SET_ENUM_NAMING_STRATEGY("setEnumNamingStrategy", "enumNamingStrategy"),
+        SET_ACCESSOR_NAMING("setAccessorNaming", "accessorNaming"),
+        SET_POLYMORPHIC_TYPE_VALIDATOR("setPolymorphicTypeValidator", "polymorphicTypeValidator"),
+
+        // Global defaults
+        SET_DATE_FORMAT("setDateFormat", "defaultDateFormat"),
+        SET_TIME_ZONE("setTimeZone", "defaultTimeZone"),
+        SET_LOCALE("setLocale", "defaultLocale"),
+        SET_BASE64_VARIANT("setBase64Variant", "defaultBase64Variant"),
+        SET_DEFAULT_ATTRIBUTES("setDefaultAttributes", "defaultAttributes"),
+        SET_DEFAULT_PROPERTY_INCLUSION("setDefaultPropertyInclusion", "defaultPropertyInclusion"),
+        SET_DEFAULT_SETTER_INFO("setDefaultSetterInfo", "defaultSetterInfo"),
+        SET_DEFAULT_MERGEABLE("setDefaultMergeable", "defaultMergeable"),
+        SET_DEFAULT_LENIENCY("setDefaultLeniency", "defaultLeniency");
 
         final String setterName;
         final String builderName;

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -215,12 +215,17 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             SetterToBuilderMapping mapping = SetterToBuilderMapping.fromSetter(mi.getName().getSimpleName());
                             assert mapping != null;
                             templateCode.append("\n.").append(mapping.builderName).append("(");
-                            for (int i = 0; i < mi.getArguments().size(); i++) {
-                                if (i > 0) {
+                            boolean first = true;
+                            for (Expression arg : mi.getArguments()) {
+                                if (arg instanceof J.Empty) {
+                                    continue;
+                                }
+                                if (!first) {
                                     templateCode.append(", ");
                                 }
+                                first = false;
                                 templateCode.append("#{any()}");
-                                templateArgs.add(mi.getArguments().get(i));
+                                templateArgs.add(arg);
                             }
                             templateCode.append(")");
                         }
@@ -244,7 +249,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         return JavaTemplate.builder(templateCode.toString())
                                 .imports(JSON_MAPPER)
                                 .javaParser(JavaParser.fromJavaVersion()
-                                        .classpathFromResources(ctx, "jackson-core-2", "jackson-databind-2"))
+                                        .classpathFromResources(ctx, "jackson-annotations-2", "jackson-core-2", "jackson-databind-2"))
                                 .build()
                                 .apply(getCursor(), nc.getCoordinates().replace(), templateArgs.toArray());
                     }

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -32,7 +32,6 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
             .classpath("jackson-core", "jackson-databind"));
     }
 
-    @DocumentExample
     @Test
     void singleDisable() {
         rewriteRun(
@@ -136,6 +135,7 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
             );
         }
 
+        @DocumentExample
         @Test
         void allSettersMigratedToBuilder() {
             rewriteRun(

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -32,6 +32,209 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
             .classpath("jackson-core", "jackson-databind"));
     }
 
+    @DocumentExample
+    @Test
+    void allSettersMigratedToBuilder() {
+        rewriteRun(
+          spec -> spec.parser(org.openrewrite.java.JavaParser.fromJavaVersion()
+            .classpath("jackson-core", "jackson-databind", "jackson-annotations")),
+          java(
+            """
+              import com.fasterxml.jackson.annotation.JsonAutoDetect;
+              import com.fasterxml.jackson.annotation.JsonInclude;
+              import com.fasterxml.jackson.annotation.JsonSetter;
+              import com.fasterxml.jackson.annotation.PropertyAccessor;
+              import com.fasterxml.jackson.core.Base64Variants;
+              import com.fasterxml.jackson.core.PrettyPrinter;
+              import com.fasterxml.jackson.databind.AnnotationIntrospector;
+              import com.fasterxml.jackson.databind.DeserializationFeature;
+              import com.fasterxml.jackson.databind.InjectableValues;
+              import com.fasterxml.jackson.databind.MapperFeature;
+              import com.fasterxml.jackson.databind.Module;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+              import com.fasterxml.jackson.databind.SerializationFeature;
+              import com.fasterxml.jackson.databind.cfg.CacheProvider;
+              import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+              import com.fasterxml.jackson.databind.cfg.ContextAttributes;
+              import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
+              import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+              import com.fasterxml.jackson.databind.introspect.AccessorNamingStrategy;
+              import com.fasterxml.jackson.databind.json.JsonMapper;
+              import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+              import com.fasterxml.jackson.databind.jsontype.SubtypeResolver;
+              import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
+              import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+              import com.fasterxml.jackson.databind.ser.FilterProvider;
+              import com.fasterxml.jackson.databind.ser.SerializerFactory;
+              import com.fasterxml.jackson.databind.type.TypeFactory;
+
+              import java.text.SimpleDateFormat;
+              import java.util.Locale;
+              import java.util.TimeZone;
+
+              class A {
+                  JsonMapper create(
+                          Module module,
+                          DeserializationProblemHandler handler,
+                          PolymorphicTypeValidator validator,
+                          TypeResolverBuilder<?> typeResolver,
+                          FilterProvider filterProvider,
+                          SerializerFactory serializerFactory,
+                          PrettyPrinter prettyPrinter,
+                          InjectableValues injectableValues,
+                          ConstructorDetector constructorDetector,
+                          CacheProvider cacheProvider,
+                          AnnotationIntrospector introspector,
+                          SubtypeResolver subtypeResolver,
+                          HandlerInstantiator handlerInstantiator,
+                          PropertyNamingStrategy namingStrategy,
+                          AccessorNamingStrategy.Provider accessorNaming,
+                          ContextAttributes attributes
+                  ) {
+                      JsonMapper mapper = new JsonMapper();
+                      mapper.configure(MapperFeature.AUTO_DETECT_FIELDS, true);
+                      mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                      mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                      mapper.registerModule(module);
+                      mapper.registerModules(module);
+                      mapper.findAndRegisterModules();
+                      mapper.addMixIn(Object.class, Comparable.class);
+                      mapper.registerSubtypes(Object.class);
+                      mapper.addHandler(handler);
+                      mapper.clearProblemHandlers();
+                      mapper.activateDefaultTyping(validator);
+                      mapper.activateDefaultTypingAsProperty(validator, ObjectMapper.DefaultTyping.NON_FINAL, "@type");
+                      mapper.deactivateDefaultTyping();
+                      mapper.setDefaultTyping(typeResolver);
+                      mapper.setFilterProvider(filterProvider);
+                      mapper.setSerializerFactory(serializerFactory);
+                      mapper.setDefaultPrettyPrinter(prettyPrinter);
+                      mapper.setInjectableValues(injectableValues);
+                      mapper.setNodeFactory(JsonNodeFactory.instance);
+                      mapper.setConstructorDetector(constructorDetector);
+                      mapper.setCacheProvider(cacheProvider);
+                      mapper.setAnnotationIntrospector(introspector);
+                      mapper.setTypeFactory(TypeFactory.defaultInstance());
+                      mapper.setSubtypeResolver(subtypeResolver);
+                      mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+                      mapper.setHandlerInstantiator(handlerInstantiator);
+                      mapper.setPropertyNamingStrategy(namingStrategy);
+                      mapper.setAccessorNaming(accessorNaming);
+                      mapper.setPolymorphicTypeValidator(validator);
+                      mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+                      mapper.setTimeZone(TimeZone.getDefault());
+                      mapper.setLocale(Locale.US);
+                      mapper.setBase64Variant(Base64Variants.MIME);
+                      mapper.setDefaultAttributes(attributes);
+                      mapper.setDefaultPropertyInclusion(JsonInclude.Value.empty());
+                      mapper.setDefaultSetterInfo(JsonSetter.Value.empty());
+                      mapper.setDefaultMergeable(Boolean.TRUE);
+                      mapper.setDefaultLeniency(Boolean.TRUE);
+                      return mapper;
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.annotation.JsonAutoDetect;
+              import com.fasterxml.jackson.annotation.JsonInclude;
+              import com.fasterxml.jackson.annotation.JsonSetter;
+              import com.fasterxml.jackson.annotation.PropertyAccessor;
+              import com.fasterxml.jackson.core.Base64Variants;
+              import com.fasterxml.jackson.core.PrettyPrinter;
+              import com.fasterxml.jackson.databind.AnnotationIntrospector;
+              import com.fasterxml.jackson.databind.DeserializationFeature;
+              import com.fasterxml.jackson.databind.InjectableValues;
+              import com.fasterxml.jackson.databind.MapperFeature;
+              import com.fasterxml.jackson.databind.Module;
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+              import com.fasterxml.jackson.databind.SerializationFeature;
+              import com.fasterxml.jackson.databind.cfg.CacheProvider;
+              import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+              import com.fasterxml.jackson.databind.cfg.ContextAttributes;
+              import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
+              import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+              import com.fasterxml.jackson.databind.introspect.AccessorNamingStrategy;
+              import com.fasterxml.jackson.databind.json.JsonMapper;
+              import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+              import com.fasterxml.jackson.databind.jsontype.SubtypeResolver;
+              import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
+              import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+              import com.fasterxml.jackson.databind.ser.FilterProvider;
+              import com.fasterxml.jackson.databind.ser.SerializerFactory;
+              import com.fasterxml.jackson.databind.type.TypeFactory;
+
+              import java.text.SimpleDateFormat;
+              import java.util.Locale;
+              import java.util.TimeZone;
+
+              class A {
+                  JsonMapper create(
+                          Module module,
+                          DeserializationProblemHandler handler,
+                          PolymorphicTypeValidator validator,
+                          TypeResolverBuilder<?> typeResolver,
+                          FilterProvider filterProvider,
+                          SerializerFactory serializerFactory,
+                          PrettyPrinter prettyPrinter,
+                          InjectableValues injectableValues,
+                          ConstructorDetector constructorDetector,
+                          CacheProvider cacheProvider,
+                          AnnotationIntrospector introspector,
+                          SubtypeResolver subtypeResolver,
+                          HandlerInstantiator handlerInstantiator,
+                          PropertyNamingStrategy namingStrategy,
+                          AccessorNamingStrategy.Provider accessorNaming,
+                          ContextAttributes attributes
+                  ) {
+                      return JsonMapper.builder()
+                              .configure(MapperFeature.AUTO_DETECT_FIELDS, true)
+                              .disable(SerializationFeature.INDENT_OUTPUT)
+                              .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                              .addModule(module)
+                              .addModules(module)
+                              .findAndAddModules()
+                              .addMixIn(Object.class, Comparable.class)
+                              .registerSubtypes(Object.class)
+                              .addHandler(handler)
+                              .clearProblemHandlers()
+                              .activateDefaultTyping(validator)
+                              .activateDefaultTypingAsProperty(validator, ObjectMapper.DefaultTyping.NON_FINAL, "@type")
+                              .deactivateDefaultTyping()
+                              .setDefaultTyping(typeResolver)
+                              .filterProvider(filterProvider)
+                              .serializerFactory(serializerFactory)
+                              .defaultPrettyPrinter(prettyPrinter)
+                              .injectableValues(injectableValues)
+                              .nodeFactory(JsonNodeFactory.instance)
+                              .constructorDetector(constructorDetector)
+                              .cacheProvider(cacheProvider)
+                              .annotationIntrospector(introspector)
+                              .typeFactory(TypeFactory.defaultInstance())
+                              .subtypeResolver(subtypeResolver)
+                              .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                              .handlerInstantiator(handlerInstantiator)
+                              .propertyNamingStrategy(namingStrategy)
+                              .accessorNaming(accessorNaming)
+                              .polymorphicTypeValidator(validator)
+                              .defaultDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
+                              .defaultTimeZone(TimeZone.getDefault())
+                              .defaultLocale(Locale.US)
+                              .defaultBase64Variant(Base64Variants.MIME)
+                              .defaultAttributes(attributes)
+                              .defaultPropertyInclusion(JsonInclude.Value.empty())
+                              .defaultSetterInfo(JsonSetter.Value.empty())
+                              .defaultMergeable(Boolean.TRUE)
+                              .defaultLeniency(Boolean.TRUE)
+                              .build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void singleDisable() {
         rewriteRun(
@@ -127,209 +330,6 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
                       JsonMapper create(Module module) {
                           return JsonMapper.builder()
                                   .addModule(module)
-                                  .build();
-                      }
-                  }
-                  """
-              )
-            );
-        }
-
-        @DocumentExample
-        @Test
-        void allSettersMigratedToBuilder() {
-            rewriteRun(
-              spec -> spec.parser(org.openrewrite.java.JavaParser.fromJavaVersion()
-                .classpath("jackson-core", "jackson-databind", "jackson-annotations")),
-              java(
-                """
-                  import com.fasterxml.jackson.annotation.JsonAutoDetect;
-                  import com.fasterxml.jackson.annotation.JsonInclude;
-                  import com.fasterxml.jackson.annotation.JsonSetter;
-                  import com.fasterxml.jackson.annotation.PropertyAccessor;
-                  import com.fasterxml.jackson.core.Base64Variants;
-                  import com.fasterxml.jackson.core.PrettyPrinter;
-                  import com.fasterxml.jackson.databind.AnnotationIntrospector;
-                  import com.fasterxml.jackson.databind.DeserializationFeature;
-                  import com.fasterxml.jackson.databind.InjectableValues;
-                  import com.fasterxml.jackson.databind.MapperFeature;
-                  import com.fasterxml.jackson.databind.Module;
-                  import com.fasterxml.jackson.databind.ObjectMapper;
-                  import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-                  import com.fasterxml.jackson.databind.SerializationFeature;
-                  import com.fasterxml.jackson.databind.cfg.CacheProvider;
-                  import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
-                  import com.fasterxml.jackson.databind.cfg.ContextAttributes;
-                  import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
-                  import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
-                  import com.fasterxml.jackson.databind.introspect.AccessorNamingStrategy;
-                  import com.fasterxml.jackson.databind.json.JsonMapper;
-                  import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
-                  import com.fasterxml.jackson.databind.jsontype.SubtypeResolver;
-                  import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
-                  import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-                  import com.fasterxml.jackson.databind.ser.FilterProvider;
-                  import com.fasterxml.jackson.databind.ser.SerializerFactory;
-                  import com.fasterxml.jackson.databind.type.TypeFactory;
-
-                  import java.text.SimpleDateFormat;
-                  import java.util.Locale;
-                  import java.util.TimeZone;
-
-                  class A {
-                      JsonMapper create(
-                              Module module,
-                              DeserializationProblemHandler handler,
-                              PolymorphicTypeValidator validator,
-                              TypeResolverBuilder<?> typeResolver,
-                              FilterProvider filterProvider,
-                              SerializerFactory serializerFactory,
-                              PrettyPrinter prettyPrinter,
-                              InjectableValues injectableValues,
-                              ConstructorDetector constructorDetector,
-                              CacheProvider cacheProvider,
-                              AnnotationIntrospector introspector,
-                              SubtypeResolver subtypeResolver,
-                              HandlerInstantiator handlerInstantiator,
-                              PropertyNamingStrategy namingStrategy,
-                              AccessorNamingStrategy.Provider accessorNaming,
-                              ContextAttributes attributes
-                      ) {
-                          JsonMapper mapper = new JsonMapper();
-                          mapper.configure(MapperFeature.AUTO_DETECT_FIELDS, true);
-                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
-                          mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-                          mapper.registerModule(module);
-                          mapper.registerModules(module);
-                          mapper.findAndRegisterModules();
-                          mapper.addMixIn(Object.class, Comparable.class);
-                          mapper.registerSubtypes(Object.class);
-                          mapper.addHandler(handler);
-                          mapper.clearProblemHandlers();
-                          mapper.activateDefaultTyping(validator);
-                          mapper.activateDefaultTypingAsProperty(validator, ObjectMapper.DefaultTyping.NON_FINAL, "@type");
-                          mapper.deactivateDefaultTyping();
-                          mapper.setDefaultTyping(typeResolver);
-                          mapper.setFilterProvider(filterProvider);
-                          mapper.setSerializerFactory(serializerFactory);
-                          mapper.setDefaultPrettyPrinter(prettyPrinter);
-                          mapper.setInjectableValues(injectableValues);
-                          mapper.setNodeFactory(JsonNodeFactory.instance);
-                          mapper.setConstructorDetector(constructorDetector);
-                          mapper.setCacheProvider(cacheProvider);
-                          mapper.setAnnotationIntrospector(introspector);
-                          mapper.setTypeFactory(TypeFactory.defaultInstance());
-                          mapper.setSubtypeResolver(subtypeResolver);
-                          mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-                          mapper.setHandlerInstantiator(handlerInstantiator);
-                          mapper.setPropertyNamingStrategy(namingStrategy);
-                          mapper.setAccessorNaming(accessorNaming);
-                          mapper.setPolymorphicTypeValidator(validator);
-                          mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
-                          mapper.setTimeZone(TimeZone.getDefault());
-                          mapper.setLocale(Locale.US);
-                          mapper.setBase64Variant(Base64Variants.MIME);
-                          mapper.setDefaultAttributes(attributes);
-                          mapper.setDefaultPropertyInclusion(JsonInclude.Value.empty());
-                          mapper.setDefaultSetterInfo(JsonSetter.Value.empty());
-                          mapper.setDefaultMergeable(Boolean.TRUE);
-                          mapper.setDefaultLeniency(Boolean.TRUE);
-                          return mapper;
-                      }
-                  }
-                  """,
-                """
-                  import com.fasterxml.jackson.annotation.JsonAutoDetect;
-                  import com.fasterxml.jackson.annotation.JsonInclude;
-                  import com.fasterxml.jackson.annotation.JsonSetter;
-                  import com.fasterxml.jackson.annotation.PropertyAccessor;
-                  import com.fasterxml.jackson.core.Base64Variants;
-                  import com.fasterxml.jackson.core.PrettyPrinter;
-                  import com.fasterxml.jackson.databind.AnnotationIntrospector;
-                  import com.fasterxml.jackson.databind.DeserializationFeature;
-                  import com.fasterxml.jackson.databind.InjectableValues;
-                  import com.fasterxml.jackson.databind.MapperFeature;
-                  import com.fasterxml.jackson.databind.Module;
-                  import com.fasterxml.jackson.databind.ObjectMapper;
-                  import com.fasterxml.jackson.databind.PropertyNamingStrategy;
-                  import com.fasterxml.jackson.databind.SerializationFeature;
-                  import com.fasterxml.jackson.databind.cfg.CacheProvider;
-                  import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
-                  import com.fasterxml.jackson.databind.cfg.ContextAttributes;
-                  import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
-                  import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
-                  import com.fasterxml.jackson.databind.introspect.AccessorNamingStrategy;
-                  import com.fasterxml.jackson.databind.json.JsonMapper;
-                  import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
-                  import com.fasterxml.jackson.databind.jsontype.SubtypeResolver;
-                  import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
-                  import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-                  import com.fasterxml.jackson.databind.ser.FilterProvider;
-                  import com.fasterxml.jackson.databind.ser.SerializerFactory;
-                  import com.fasterxml.jackson.databind.type.TypeFactory;
-
-                  import java.text.SimpleDateFormat;
-                  import java.util.Locale;
-                  import java.util.TimeZone;
-
-                  class A {
-                      JsonMapper create(
-                              Module module,
-                              DeserializationProblemHandler handler,
-                              PolymorphicTypeValidator validator,
-                              TypeResolverBuilder<?> typeResolver,
-                              FilterProvider filterProvider,
-                              SerializerFactory serializerFactory,
-                              PrettyPrinter prettyPrinter,
-                              InjectableValues injectableValues,
-                              ConstructorDetector constructorDetector,
-                              CacheProvider cacheProvider,
-                              AnnotationIntrospector introspector,
-                              SubtypeResolver subtypeResolver,
-                              HandlerInstantiator handlerInstantiator,
-                              PropertyNamingStrategy namingStrategy,
-                              AccessorNamingStrategy.Provider accessorNaming,
-                              ContextAttributes attributes
-                      ) {
-                          return JsonMapper.builder()
-                                  .configure(MapperFeature.AUTO_DETECT_FIELDS, true)
-                                  .disable(SerializationFeature.INDENT_OUTPUT)
-                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                                  .addModule(module)
-                                  .addModules(module)
-                                  .findAndAddModules()
-                                  .addMixIn(Object.class, Comparable.class)
-                                  .registerSubtypes(Object.class)
-                                  .addHandler(handler)
-                                  .clearProblemHandlers()
-                                  .activateDefaultTyping(validator)
-                                  .activateDefaultTypingAsProperty(validator, ObjectMapper.DefaultTyping.NON_FINAL, "@type")
-                                  .deactivateDefaultTyping()
-                                  .setDefaultTyping(typeResolver)
-                                  .filterProvider(filterProvider)
-                                  .serializerFactory(serializerFactory)
-                                  .defaultPrettyPrinter(prettyPrinter)
-                                  .injectableValues(injectableValues)
-                                  .nodeFactory(JsonNodeFactory.instance)
-                                  .constructorDetector(constructorDetector)
-                                  .cacheProvider(cacheProvider)
-                                  .annotationIntrospector(introspector)
-                                  .typeFactory(TypeFactory.defaultInstance())
-                                  .subtypeResolver(subtypeResolver)
-                                  .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
-                                  .handlerInstantiator(handlerInstantiator)
-                                  .propertyNamingStrategy(namingStrategy)
-                                  .accessorNaming(accessorNaming)
-                                  .polymorphicTypeValidator(validator)
-                                  .defaultDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
-                                  .defaultTimeZone(TimeZone.getDefault())
-                                  .defaultLocale(Locale.US)
-                                  .defaultBase64Variant(Base64Variants.MIME)
-                                  .defaultAttributes(attributes)
-                                  .defaultPropertyInclusion(JsonInclude.Value.empty())
-                                  .defaultSetterInfo(JsonSetter.Value.empty())
-                                  .defaultMergeable(Boolean.TRUE)
-                                  .defaultLeniency(Boolean.TRUE)
                                   .build();
                       }
                   }

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -137,6 +137,208 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
         }
 
         @Test
+        void allSettersMigratedToBuilder() {
+            rewriteRun(
+              spec -> spec.parser(org.openrewrite.java.JavaParser.fromJavaVersion()
+                .classpath("jackson-core", "jackson-databind", "jackson-annotations")),
+              java(
+                """
+                  import com.fasterxml.jackson.annotation.JsonAutoDetect;
+                  import com.fasterxml.jackson.annotation.JsonInclude;
+                  import com.fasterxml.jackson.annotation.JsonSetter;
+                  import com.fasterxml.jackson.annotation.PropertyAccessor;
+                  import com.fasterxml.jackson.core.Base64Variants;
+                  import com.fasterxml.jackson.core.PrettyPrinter;
+                  import com.fasterxml.jackson.databind.AnnotationIntrospector;
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.InjectableValues;
+                  import com.fasterxml.jackson.databind.MapperFeature;
+                  import com.fasterxml.jackson.databind.Module;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.cfg.CacheProvider;
+                  import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+                  import com.fasterxml.jackson.databind.cfg.ContextAttributes;
+                  import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
+                  import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+                  import com.fasterxml.jackson.databind.introspect.AccessorNamingStrategy;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+                  import com.fasterxml.jackson.databind.jsontype.SubtypeResolver;
+                  import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
+                  import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+                  import com.fasterxml.jackson.databind.ser.FilterProvider;
+                  import com.fasterxml.jackson.databind.ser.SerializerFactory;
+                  import com.fasterxml.jackson.databind.type.TypeFactory;
+
+                  import java.text.SimpleDateFormat;
+                  import java.util.Locale;
+                  import java.util.TimeZone;
+
+                  class A {
+                      JsonMapper create(
+                              Module module,
+                              DeserializationProblemHandler handler,
+                              PolymorphicTypeValidator validator,
+                              TypeResolverBuilder<?> typeResolver,
+                              FilterProvider filterProvider,
+                              SerializerFactory serializerFactory,
+                              PrettyPrinter prettyPrinter,
+                              InjectableValues injectableValues,
+                              ConstructorDetector constructorDetector,
+                              CacheProvider cacheProvider,
+                              AnnotationIntrospector introspector,
+                              SubtypeResolver subtypeResolver,
+                              HandlerInstantiator handlerInstantiator,
+                              PropertyNamingStrategy namingStrategy,
+                              AccessorNamingStrategy.Provider accessorNaming,
+                              ContextAttributes attributes
+                      ) {
+                          JsonMapper mapper = new JsonMapper();
+                          mapper.configure(MapperFeature.AUTO_DETECT_FIELDS, true);
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                          mapper.registerModule(module);
+                          mapper.registerModules(module);
+                          mapper.findAndRegisterModules();
+                          mapper.addMixIn(Object.class, Comparable.class);
+                          mapper.registerSubtypes(Object.class);
+                          mapper.addHandler(handler);
+                          mapper.clearProblemHandlers();
+                          mapper.activateDefaultTyping(validator);
+                          mapper.activateDefaultTypingAsProperty(validator, ObjectMapper.DefaultTyping.NON_FINAL, "@type");
+                          mapper.deactivateDefaultTyping();
+                          mapper.setDefaultTyping(typeResolver);
+                          mapper.setFilterProvider(filterProvider);
+                          mapper.setSerializerFactory(serializerFactory);
+                          mapper.setDefaultPrettyPrinter(prettyPrinter);
+                          mapper.setInjectableValues(injectableValues);
+                          mapper.setNodeFactory(JsonNodeFactory.instance);
+                          mapper.setConstructorDetector(constructorDetector);
+                          mapper.setCacheProvider(cacheProvider);
+                          mapper.setAnnotationIntrospector(introspector);
+                          mapper.setTypeFactory(TypeFactory.defaultInstance());
+                          mapper.setSubtypeResolver(subtypeResolver);
+                          mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+                          mapper.setHandlerInstantiator(handlerInstantiator);
+                          mapper.setPropertyNamingStrategy(namingStrategy);
+                          mapper.setAccessorNaming(accessorNaming);
+                          mapper.setPolymorphicTypeValidator(validator);
+                          mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+                          mapper.setTimeZone(TimeZone.getDefault());
+                          mapper.setLocale(Locale.US);
+                          mapper.setBase64Variant(Base64Variants.MIME);
+                          mapper.setDefaultAttributes(attributes);
+                          mapper.setDefaultPropertyInclusion(JsonInclude.Value.empty());
+                          mapper.setDefaultSetterInfo(JsonSetter.Value.empty());
+                          mapper.setDefaultMergeable(Boolean.TRUE);
+                          mapper.setDefaultLeniency(Boolean.TRUE);
+                          return mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.annotation.JsonAutoDetect;
+                  import com.fasterxml.jackson.annotation.JsonInclude;
+                  import com.fasterxml.jackson.annotation.JsonSetter;
+                  import com.fasterxml.jackson.annotation.PropertyAccessor;
+                  import com.fasterxml.jackson.core.Base64Variants;
+                  import com.fasterxml.jackson.core.PrettyPrinter;
+                  import com.fasterxml.jackson.databind.AnnotationIntrospector;
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.InjectableValues;
+                  import com.fasterxml.jackson.databind.MapperFeature;
+                  import com.fasterxml.jackson.databind.Module;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.cfg.CacheProvider;
+                  import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+                  import com.fasterxml.jackson.databind.cfg.ContextAttributes;
+                  import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
+                  import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+                  import com.fasterxml.jackson.databind.introspect.AccessorNamingStrategy;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+                  import com.fasterxml.jackson.databind.jsontype.SubtypeResolver;
+                  import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
+                  import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+                  import com.fasterxml.jackson.databind.ser.FilterProvider;
+                  import com.fasterxml.jackson.databind.ser.SerializerFactory;
+                  import com.fasterxml.jackson.databind.type.TypeFactory;
+
+                  import java.text.SimpleDateFormat;
+                  import java.util.Locale;
+                  import java.util.TimeZone;
+
+                  class A {
+                      JsonMapper create(
+                              Module module,
+                              DeserializationProblemHandler handler,
+                              PolymorphicTypeValidator validator,
+                              TypeResolverBuilder<?> typeResolver,
+                              FilterProvider filterProvider,
+                              SerializerFactory serializerFactory,
+                              PrettyPrinter prettyPrinter,
+                              InjectableValues injectableValues,
+                              ConstructorDetector constructorDetector,
+                              CacheProvider cacheProvider,
+                              AnnotationIntrospector introspector,
+                              SubtypeResolver subtypeResolver,
+                              HandlerInstantiator handlerInstantiator,
+                              PropertyNamingStrategy namingStrategy,
+                              AccessorNamingStrategy.Provider accessorNaming,
+                              ContextAttributes attributes
+                      ) {
+                          return JsonMapper.builder()
+                                  .configure(MapperFeature.AUTO_DETECT_FIELDS, true)
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                  .addModule(module)
+                                  .addModules(module)
+                                  .findAndAddModules()
+                                  .addMixIn(Object.class, Comparable.class)
+                                  .registerSubtypes(Object.class)
+                                  .addHandler(handler)
+                                  .clearProblemHandlers()
+                                  .activateDefaultTyping(validator)
+                                  .activateDefaultTypingAsProperty(validator, ObjectMapper.DefaultTyping.NON_FINAL, "@type")
+                                  .deactivateDefaultTyping()
+                                  .setDefaultTyping(typeResolver)
+                                  .filterProvider(filterProvider)
+                                  .serializerFactory(serializerFactory)
+                                  .defaultPrettyPrinter(prettyPrinter)
+                                  .injectableValues(injectableValues)
+                                  .nodeFactory(JsonNodeFactory.instance)
+                                  .constructorDetector(constructorDetector)
+                                  .cacheProvider(cacheProvider)
+                                  .annotationIntrospector(introspector)
+                                  .typeFactory(TypeFactory.defaultInstance())
+                                  .subtypeResolver(subtypeResolver)
+                                  .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                                  .handlerInstantiator(handlerInstantiator)
+                                  .propertyNamingStrategy(namingStrategy)
+                                  .accessorNaming(accessorNaming)
+                                  .polymorphicTypeValidator(validator)
+                                  .defaultDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
+                                  .defaultTimeZone(TimeZone.getDefault())
+                                  .defaultLocale(Locale.US)
+                                  .defaultBase64Variant(Base64Variants.MIME)
+                                  .defaultAttributes(attributes)
+                                  .defaultPropertyInclusion(JsonInclude.Value.empty())
+                                  .defaultSetterInfo(JsonSetter.Value.empty())
+                                  .defaultMergeable(Boolean.TRUE)
+                                  .defaultLeniency(Boolean.TRUE)
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void setDateFormatRenamedToDefaultDateFormat() {
             rewriteRun(
               java(


### PR DESCRIPTION
## Summary
- Expand the `SetterToBuilderMapping` enum from 7 to 39 entries, covering all `ObjectMapper` setter methods that have `MapperBuilder` equivalents
- Includes `configure`, `registerModules`, `findAndRegisterModules`, `registerSubtypes`, default typing methods, serialization/deserialization settings, introspection/naming configuration, and global defaults (`timeZone`, `locale`, `base64Variant`, etc.)
- Methods without builder equivalents (`setSerializerProvider`, `setMixIns`, `setMixInResolver`, `setAnnotationIntrospectors`, `setConfig`, `setDefaultVisibility`) are intentionally excluded

- Fixes https://github.com/moderneinc/customer-requests/issues/2012