### PR TITLE
Handle fluent-chained setter calls in MigrateMapperSettersToBuilder

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -232,7 +232,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
 
                         doAfterVisit(new InlineVariable().getVisitor());
 
-                        return applyBuilderTemplate(builderSetters, null, nc.getCoordinates().replace(), ctx);
+                        return applyBuilderTemplate(builderSetters, null, Collections.emptyList(),
+                                nc.getCoordinates().replace(), ctx);
                     }
 
                     @Override
@@ -339,17 +340,31 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             return null;
                         }
 
-                        // Resolve all mappings up front; bail if any call is unknown
-                        List<SetterToBuilderMapping> mappings = new ArrayList<>(chainCalls.size());
+                        // Split chain into known setters (prefix) and remaining calls (suffix)
+                        List<J.MethodInvocation> setterCalls = new ArrayList<>();
+                        List<SetterToBuilderMapping> mappings = new ArrayList<>();
+                        List<J.MethodInvocation> suffixCalls = new ArrayList<>();
+                        boolean hitUnknown = false;
                         for (J.MethodInvocation call : chainCalls) {
-                            SetterToBuilderMapping m = SetterToBuilderMapping.fromSetter(call.getName().getSimpleName());
-                            if (m == null) {
-                                return null;
+                            if (!hitUnknown) {
+                                SetterToBuilderMapping m = SetterToBuilderMapping.fromSetter(call.getName().getSimpleName());
+                                if (m != null) {
+                                    setterCalls.add(call);
+                                    mappings.add(m);
+                                    continue;
+                                }
+                                hitUnknown = true;
                             }
-                            mappings.add(m);
+                            suffixCalls.add(call);
                         }
 
-                        return applyBuilderTemplate(chainCalls, mappings, mi.getCoordinates().replace(), ctx);
+                        // Need at least one known setter to migrate
+                        if (setterCalls.isEmpty()) {
+                            return null;
+                        }
+
+                        return applyBuilderTemplate(setterCalls, mappings, suffixCalls,
+                                mi.getCoordinates().replace(), ctx);
                     }
 
                     /**
@@ -357,6 +372,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                      */
                     private J applyBuilderTemplate(List<J.MethodInvocation> setters,
                                                    @Nullable List<SetterToBuilderMapping> resolvedMappings,
+                                                   List<J.MethodInvocation> suffixCalls,
                                                    JavaCoordinates coordinates, ExecutionContext ctx) {
                         StringBuilder templateCode = new StringBuilder("JsonMapper.builder()");
                         List<Expression> templateArgs = new ArrayList<>();
@@ -369,6 +385,24 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             appendBuilderCall(setter, mapping, templateCode, templateArgs);
                         }
                         templateCode.append("\n.build()");
+
+                        // Append any non-setter calls that follow the known setters
+                        for (J.MethodInvocation suffix : suffixCalls) {
+                            templateCode.append("\n.").append(suffix.getName().getSimpleName()).append("(");
+                            boolean first = true;
+                            for (Expression arg : suffix.getArguments()) {
+                                if (arg instanceof J.Empty) {
+                                    continue;
+                                }
+                                if (!first) {
+                                    templateCode.append(", ");
+                                }
+                                first = false;
+                                templateCode.append("#{any()}");
+                                templateArgs.add(arg);
+                            }
+                            templateCode.append(")");
+                        }
 
                         maybeAddImport(JSON_MAPPER);
                         maybeAddImport(JSON_INCLUDE);

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -104,13 +104,18 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         final String setterName;
         final String builderName;
 
-        static @Nullable SetterToBuilderMapping fromSetter(String name) {
+        private static final Map<String, SetterToBuilderMapping> BY_SETTER_NAME;
+
+        static {
+            Map<String, SetterToBuilderMapping> map = new HashMap<>();
             for (SetterToBuilderMapping m : values()) {
-                if (m.setterName.equals(name)) {
-                    return m;
-                }
+                map.put(m.setterName, m);
             }
-            return null;
+            BY_SETTER_NAME = map;
+        }
+
+        static @Nullable SetterToBuilderMapping fromSetter(String name) {
+            return BY_SETTER_NAME.get(name);
         }
     }
 
@@ -227,7 +232,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
 
                         doAfterVisit(new InlineVariable().getVisitor());
 
-                        return applyBuilderTemplate(builderSetters, nc.getCoordinates().replace(), ctx);
+                        return applyBuilderTemplate(builderSetters, null, nc.getCoordinates().replace(), ctx);
                     }
 
                     @Override
@@ -334,27 +339,34 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             return null;
                         }
 
-                        // Only convert if all chained calls are known setters
+                        // Resolve all mappings up front; bail if any call is unknown
+                        List<SetterToBuilderMapping> mappings = new ArrayList<>(chainCalls.size());
                         for (J.MethodInvocation call : chainCalls) {
-                            if (SetterToBuilderMapping.fromSetter(call.getName().getSimpleName()) == null) {
+                            SetterToBuilderMapping m = SetterToBuilderMapping.fromSetter(call.getName().getSimpleName());
+                            if (m == null) {
                                 return null;
                             }
+                            mappings.add(m);
                         }
 
-                        return applyBuilderTemplate(chainCalls, mi.getCoordinates().replace(), ctx);
+                        return applyBuilderTemplate(chainCalls, mappings, mi.getCoordinates().replace(), ctx);
                     }
 
                     /**
                      * Builds and applies the {@code JsonMapper.builder()...build()} template for a list of setter calls.
                      */
                     private J applyBuilderTemplate(List<J.MethodInvocation> setters,
+                                                   @Nullable List<SetterToBuilderMapping> resolvedMappings,
                                                    JavaCoordinates coordinates, ExecutionContext ctx) {
                         StringBuilder templateCode = new StringBuilder("JsonMapper.builder()");
                         List<Expression> templateArgs = new ArrayList<>();
                         boolean needsJsonIncludeImport = false;
 
-                        for (J.MethodInvocation setter : setters) {
-                            SetterToBuilderMapping mapping = SetterToBuilderMapping.fromSetter(setter.getName().getSimpleName());
+                        for (int i = 0; i < setters.size(); i++) {
+                            J.MethodInvocation setter = setters.get(i);
+                            SetterToBuilderMapping mapping = resolvedMappings != null
+                                    ? resolvedMappings.get(i)
+                                    : SetterToBuilderMapping.fromSetter(setter.getName().getSimpleName());
                             assert mapping != null;
                             needsJsonIncludeImport |= appendBuilderCall(setter, mapping, templateCode, templateArgs);
                         }

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -214,18 +214,6 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             return nc;
                         }
 
-                        // Build template with #{any()} placeholders
-                        StringBuilder templateCode = new StringBuilder("JsonMapper.builder()");
-                        List<Expression> templateArgs = new ArrayList<>();
-                        boolean needsJsonIncludeImport = false;
-
-                        for (J.MethodInvocation setter : builderSetters) {
-                            SetterToBuilderMapping mapping = SetterToBuilderMapping.fromSetter(setter.getName().getSimpleName());
-                            assert mapping != null;
-                            needsJsonIncludeImport |= appendBuilderCall(setter, mapping, templateCode, templateArgs);
-                        }
-                        templateCode.append("\n.build()");
-
                         // Mark setter invocations for removal
                         Cursor blockCursor = getCursor().dropParentUntil(J.Block.class::isInstance);
                         Set<UUID> toRemove = blockCursor.getMessage(INVOCATIONS_TO_REMOVE);
@@ -237,19 +225,9 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             toRemove.add(setter.getId());
                         }
 
-                        maybeAddImport(JSON_MAPPER);
-                        if (needsJsonIncludeImport) {
-                            maybeAddImport(JSON_INCLUDE);
-                        }
-
                         doAfterVisit(new InlineVariable().getVisitor());
 
-                        return JavaTemplate.builder(templateCode.toString())
-                                .imports(JSON_MAPPER, JSON_INCLUDE)
-                                .javaParser(JavaParser.fromJavaVersion()
-                                        .classpathFromResources(ctx, "jackson-annotations-2", "jackson-core-2", "jackson-databind-2"))
-                                .build()
-                                .apply(getCursor(), nc.getCoordinates().replace(), templateArgs.toArray());
+                        return applyBuilderTemplate(builderSetters, nc.getCoordinates().replace(), ctx);
                     }
 
                     @Override
@@ -363,14 +341,22 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             }
                         }
 
+                        return applyBuilderTemplate(chainCalls, mi.getCoordinates().replace(), ctx);
+                    }
+
+                    /**
+                     * Builds and applies the {@code JsonMapper.builder()...build()} template for a list of setter calls.
+                     */
+                    private J applyBuilderTemplate(List<J.MethodInvocation> setters,
+                                                   JavaCoordinates coordinates, ExecutionContext ctx) {
                         StringBuilder templateCode = new StringBuilder("JsonMapper.builder()");
                         List<Expression> templateArgs = new ArrayList<>();
                         boolean needsJsonIncludeImport = false;
 
-                        for (J.MethodInvocation call : chainCalls) {
-                            SetterToBuilderMapping mapping = SetterToBuilderMapping.fromSetter(call.getName().getSimpleName());
+                        for (J.MethodInvocation setter : setters) {
+                            SetterToBuilderMapping mapping = SetterToBuilderMapping.fromSetter(setter.getName().getSimpleName());
                             assert mapping != null;
-                            needsJsonIncludeImport |= appendBuilderCall(call, mapping, templateCode, templateArgs);
+                            needsJsonIncludeImport |= appendBuilderCall(setter, mapping, templateCode, templateArgs);
                         }
                         templateCode.append("\n.build()");
 
@@ -384,7 +370,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                 .javaParser(JavaParser.fromJavaVersion()
                                         .classpathFromResources(ctx, "jackson-annotations-2", "jackson-core-2", "jackson-databind-2"))
                                 .build()
-                                .apply(getCursor(), mi.getCoordinates().replace(), templateArgs.toArray());
+                                .apply(getCursor(), coordinates, templateArgs.toArray());
                     }
                 }
         );

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -360,22 +360,18 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                                    JavaCoordinates coordinates, ExecutionContext ctx) {
                         StringBuilder templateCode = new StringBuilder("JsonMapper.builder()");
                         List<Expression> templateArgs = new ArrayList<>();
-                        boolean needsJsonIncludeImport = false;
-
                         for (int i = 0; i < setters.size(); i++) {
                             J.MethodInvocation setter = setters.get(i);
                             SetterToBuilderMapping mapping = resolvedMappings != null
                                     ? resolvedMappings.get(i)
                                     : SetterToBuilderMapping.fromSetter(setter.getName().getSimpleName());
                             assert mapping != null;
-                            needsJsonIncludeImport |= appendBuilderCall(setter, mapping, templateCode, templateArgs);
+                            appendBuilderCall(setter, mapping, templateCode, templateArgs);
                         }
                         templateCode.append("\n.build()");
 
                         maybeAddImport(JSON_MAPPER);
-                        if (needsJsonIncludeImport) {
-                            maybeAddImport(JSON_INCLUDE);
-                        }
+                        maybeAddImport(JSON_INCLUDE);
 
                         return JavaTemplate.builder(templateCode.toString())
                                 .imports(JSON_MAPPER, JSON_INCLUDE)
@@ -411,8 +407,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
      * Appends a single builder method call to the template string.
      * Returns {@code true} if the call requires the {@code JsonInclude} import.
      */
-    private static boolean appendBuilderCall(J.MethodInvocation mi, SetterToBuilderMapping mapping,
-                                             StringBuilder templateCode, List<Expression> templateArgs) {
+    private static void appendBuilderCall(J.MethodInvocation mi, SetterToBuilderMapping mapping,
+                                           StringBuilder templateCode, List<Expression> templateArgs) {
         // Special case: setDefaultPropertyInclusion(JsonInclude.Include.X) needs wrapping
         // because the builder's defaultPropertyInclusion() expects a JsonInclude.Value, not a raw Include
         if (mapping == SetterToBuilderMapping.SET_DEFAULT_PROPERTY_INCLUSION &&
@@ -422,7 +418,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
             templateCode.append("\n.defaultPropertyInclusion(JsonInclude.Value.construct(#{any()}, #{any()}))");
             templateArgs.add(mi.getArguments().get(0));
             templateArgs.add(mi.getArguments().get(0));
-            return true;
+            return;
         }
 
         templateCode.append("\n.").append(mapping.builderName).append("(");
@@ -439,6 +435,5 @@ public class MigrateMapperSettersToBuilder extends Recipe {
             templateArgs.add(arg);
         }
         templateCode.append(")");
-        return false;
     }
 }

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -39,6 +39,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
     private static final MethodMatcher JSON_MAPPER_NO_ARG_CTOR = new MethodMatcher(JSON_MAPPER + " <constructor>()");
 
     private static final String INVOCATIONS_TO_REMOVE = "INVOCATIONS_TO_REMOVE";
+    private static final String JSON_INCLUDE = "com.fasterxml.jackson.annotation.JsonInclude";
+    private static final String JSON_INCLUDE_INCLUDE = "com.fasterxml.jackson.annotation.JsonInclude$Include";
 
     @RequiredArgsConstructor
     enum SetterToBuilderMapping {
@@ -133,6 +135,11 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             return nc;
                         }
 
+                        // Skip if constructor is part of a fluent chain - handled by visitMethodInvocation
+                        if (getCursor().getParentTreeCursor().getValue() instanceof J.MethodInvocation) {
+                            return nc;
+                        }
+
                         // Determine variable identifier from local declaration or field assignment
                         J.Identifier varIdent;
                         J.VariableDeclarations.NamedVariable namedVar = getCursor().firstEnclosing(J.VariableDeclarations.NamedVariable.class);
@@ -210,24 +217,12 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         // Build template with #{any()} placeholders
                         StringBuilder templateCode = new StringBuilder("JsonMapper.builder()");
                         List<Expression> templateArgs = new ArrayList<>();
+                        boolean needsJsonIncludeImport = false;
 
-                        for (J.MethodInvocation mi : builderSetters) {
-                            SetterToBuilderMapping mapping = SetterToBuilderMapping.fromSetter(mi.getName().getSimpleName());
+                        for (J.MethodInvocation setter : builderSetters) {
+                            SetterToBuilderMapping mapping = SetterToBuilderMapping.fromSetter(setter.getName().getSimpleName());
                             assert mapping != null;
-                            templateCode.append("\n.").append(mapping.builderName).append("(");
-                            boolean first = true;
-                            for (Expression arg : mi.getArguments()) {
-                                if (arg instanceof J.Empty) {
-                                    continue;
-                                }
-                                if (!first) {
-                                    templateCode.append(", ");
-                                }
-                                first = false;
-                                templateCode.append("#{any()}");
-                                templateArgs.add(arg);
-                            }
-                            templateCode.append(")");
+                            needsJsonIncludeImport |= appendBuilderCall(setter, mapping, templateCode, templateArgs);
                         }
                         templateCode.append("\n.build()");
 
@@ -238,16 +233,19 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             toRemove = new HashSet<>();
                             blockCursor.putMessage(INVOCATIONS_TO_REMOVE, toRemove);
                         }
-                        for (J.MethodInvocation mi : builderSetters) {
-                            toRemove.add(mi.getId());
+                        for (J.MethodInvocation setter : builderSetters) {
+                            toRemove.add(setter.getId());
                         }
 
                         maybeAddImport(JSON_MAPPER);
+                        if (needsJsonIncludeImport) {
+                            maybeAddImport(JSON_INCLUDE);
+                        }
 
                         doAfterVisit(new InlineVariable().getVisitor());
 
                         return JavaTemplate.builder(templateCode.toString())
-                                .imports(JSON_MAPPER)
+                                .imports(JSON_MAPPER, JSON_INCLUDE)
                                 .javaParser(JavaParser.fromJavaVersion()
                                         .classpathFromResources(ctx, "jackson-annotations-2", "jackson-core-2", "jackson-databind-2"))
                                 .build()
@@ -262,6 +260,14 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         Set<UUID> toRemove = getCursor().getNearestMessage(INVOCATIONS_TO_REMOVE);
                         if (toRemove != null && toRemove.contains(mi.getId())) {
                             return null;
+                        }
+
+                        // Check for fluent chain on new JsonMapper()
+                        if (isFluentChainHead(method)) {
+                            J result = tryMigrateFluentChain(mi, ctx);
+                            if (result != null) {
+                                return result;
+                            }
                         }
 
                         if (!(mi.getSelect() instanceof J.Identifier) ||
@@ -327,7 +333,114 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             }
                         }.reduce(stmt, new HashSet<>()).isEmpty();
                     }
+
+                    /**
+                     * Check if this method invocation is the outermost call in a fluent chain
+                     * (i.e., it is not itself the select of another method invocation).
+                     */
+                    private boolean isFluentChainHead(J.MethodInvocation method) {
+                        Object parent = getCursor().getParentTreeCursor().getValue();
+                        if (parent instanceof J.MethodInvocation) {
+                            return ((J.MethodInvocation) parent).getSelect() != method;
+                        }
+                        return true;
+                    }
+
+                    /**
+                     * If this method invocation is the outermost call of a fluent chain rooted
+                     * at {@code new JsonMapper()}, migrate the chain to the builder pattern.
+                     */
+                    private @Nullable J tryMigrateFluentChain(J.MethodInvocation mi, ExecutionContext ctx) {
+                        List<J.MethodInvocation> chainCalls = collectFluentChain(mi);
+                        if (chainCalls == null) {
+                            return null;
+                        }
+
+                        // Only convert if all chained calls are known setters
+                        for (J.MethodInvocation call : chainCalls) {
+                            if (SetterToBuilderMapping.fromSetter(call.getName().getSimpleName()) == null) {
+                                return null;
+                            }
+                        }
+
+                        StringBuilder templateCode = new StringBuilder("JsonMapper.builder()");
+                        List<Expression> templateArgs = new ArrayList<>();
+                        boolean needsJsonIncludeImport = false;
+
+                        for (J.MethodInvocation call : chainCalls) {
+                            SetterToBuilderMapping mapping = SetterToBuilderMapping.fromSetter(call.getName().getSimpleName());
+                            assert mapping != null;
+                            needsJsonIncludeImport |= appendBuilderCall(call, mapping, templateCode, templateArgs);
+                        }
+                        templateCode.append("\n.build()");
+
+                        maybeAddImport(JSON_MAPPER);
+                        if (needsJsonIncludeImport) {
+                            maybeAddImport(JSON_INCLUDE);
+                        }
+
+                        return JavaTemplate.builder(templateCode.toString())
+                                .imports(JSON_MAPPER, JSON_INCLUDE)
+                                .javaParser(JavaParser.fromJavaVersion()
+                                        .classpathFromResources(ctx, "jackson-annotations-2", "jackson-core-2", "jackson-databind-2"))
+                                .build()
+                                .apply(getCursor(), mi.getCoordinates().replace(), templateArgs.toArray());
+                    }
                 }
         );
+    }
+
+    /**
+     * Walk the select chain of a method invocation to find a fluent chain rooted at
+     * {@code new JsonMapper()}. Returns the chain calls in innermost-first order,
+     * or {@code null} if the chain is not rooted at {@code new JsonMapper()}.
+     */
+    private static @Nullable List<J.MethodInvocation> collectFluentChain(J.MethodInvocation mi) {
+        List<J.MethodInvocation> calls = new ArrayList<>();
+        Expression current = mi;
+        while (current instanceof J.MethodInvocation) {
+            calls.add((J.MethodInvocation) current);
+            current = ((J.MethodInvocation) current).getSelect();
+        }
+        if (current instanceof J.NewClass && JSON_MAPPER_NO_ARG_CTOR.matches((J.NewClass) current)) {
+            Collections.reverse(calls);
+            return calls;
+        }
+        return null;
+    }
+
+    /**
+     * Appends a single builder method call to the template string.
+     * Returns {@code true} if the call requires the {@code JsonInclude} import.
+     */
+    private static boolean appendBuilderCall(J.MethodInvocation mi, SetterToBuilderMapping mapping,
+                                             StringBuilder templateCode, List<Expression> templateArgs) {
+        // Special case: setDefaultPropertyInclusion(JsonInclude.Include.X) needs wrapping
+        // because the builder's defaultPropertyInclusion() expects a JsonInclude.Value, not a raw Include
+        if (mapping == SetterToBuilderMapping.SET_DEFAULT_PROPERTY_INCLUSION &&
+                mi.getArguments().size() == 1 &&
+                !(mi.getArguments().get(0) instanceof J.Empty) &&
+                TypeUtils.isAssignableTo(JSON_INCLUDE_INCLUDE, mi.getArguments().get(0).getType())) {
+            templateCode.append("\n.defaultPropertyInclusion(JsonInclude.Value.construct(#{any()}, #{any()}))");
+            templateArgs.add(mi.getArguments().get(0));
+            templateArgs.add(mi.getArguments().get(0));
+            return true;
+        }
+
+        templateCode.append("\n.").append(mapping.builderName).append("(");
+        boolean first = true;
+        for (Expression arg : mi.getArguments()) {
+            if (arg instanceof J.Empty) {
+                continue;
+            }
+            if (!first) {
+                templateCode.append(", ");
+            }
+            first = false;
+            templateCode.append("#{any()}");
+            templateArgs.add(arg);
+        }
+        templateCode.append(")");
+        return false;
     }
 }

--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -39,17 +39,17 @@ recipeList:
   - org.openrewrite.java.jackson.LombokJacksonizedConfig
   - org.openrewrite.java.jackson.UpdateSerializationInclusionConfiguration
   - org.openrewrite.java.jackson.UseFormatAlignedObjectMappers
+  - org.openrewrite.java.jackson.UpgradeJackson_2_3_RemoveRedundantFeatureFlags
+  - org.openrewrite.java.jackson.RemoveBuiltInModuleRegistrations
   - org.openrewrite.java.jackson.MigrateMapperSettersToBuilder
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_Dependencies
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_TypeChanges
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_MethodRenames
-  - org.openrewrite.java.jackson.UpgradeJackson_2_3_RemoveRedundantFeatureFlags
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_RelocatedFeatureConstants
   - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
       existingFullyQualifiedConstantName: com.fasterxml.jackson.core.JsonToken.FIELD_NAME
       fullyQualifiedConstantName: com.fasterxml.jackson.core.JsonToken.PROPERTY_NAME
   - org.openrewrite.java.jackson.ReplaceObjectMapperCopy
-  - org.openrewrite.java.jackson.RemoveBuiltInModuleRegistrations
   - org.openrewrite.java.jackson.UseModernDateTimeSerialization
   - org.openrewrite.java.jackson.ReplaceStreamWriteCapability
   - org.openrewrite.java.jackson.ReplaceJsonIgnoreWithJsonSetter

--- a/src/test/java/org/openrewrite/java/jackson/KotlinUpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/java/jackson/KotlinUpgradeJackson_2_3Test.java
@@ -120,7 +120,11 @@ class KotlinUpgradeJackson_2_3Test implements RewriteTest {
     @Test
     void fullPipelineChainedConfigurationOnObjectMapper() {
         rewriteRun(
-          spec -> spec.recipeFromResources("org.openrewrite.java.jackson.UpgradeJackson_2_3"),
+          spec -> spec
+            .parser(KotlinParser.builder()
+              .classpath("jackson-annotations", "jackson-core", "jackson-databind",
+                "jackson-datatype-jsr310"))
+            .recipeFromResources("org.openrewrite.java.jackson.UpgradeJackson_2_3"),
           //language=kotlin
           kotlin(
             """
@@ -128,11 +132,13 @@ class KotlinUpgradeJackson_2_3Test implements RewriteTest {
               import com.fasterxml.jackson.databind.DeserializationFeature
               import com.fasterxml.jackson.databind.ObjectMapper
               import com.fasterxml.jackson.databind.SerializationFeature
+              import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
               import java.util.TimeZone
 
               class Test {
                   fun objectMapper(): ObjectMapper {
                       return ObjectMapper()
+                              .registerModule(JavaTimeModule())
                               .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                               .setTimeZone(TimeZone.getDefault())
                               .setSerializationInclusion(JsonInclude.Include.NON_NULL)
@@ -144,7 +150,6 @@ class KotlinUpgradeJackson_2_3Test implements RewriteTest {
               import com.fasterxml.jackson.annotation.JsonInclude
               import tools.jackson.databind.ObjectMapper
               import tools.jackson.databind.json.JsonMapper
-
               import java.util.TimeZone
 
               class Test {

--- a/src/test/java/org/openrewrite/java/jackson/KotlinUpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/java/jackson/KotlinUpgradeJackson_2_3Test.java
@@ -118,6 +118,49 @@ class KotlinUpgradeJackson_2_3Test implements RewriteTest {
     }
 
     @Test
+    void fullPipelineChainedConfigurationOnObjectMapper() {
+        rewriteRun(
+          spec -> spec.recipeFromResources("org.openrewrite.java.jackson.UpgradeJackson_2_3"),
+          //language=kotlin
+          kotlin(
+            """
+              import com.fasterxml.jackson.annotation.JsonInclude
+              import com.fasterxml.jackson.databind.DeserializationFeature
+              import com.fasterxml.jackson.databind.ObjectMapper
+              import com.fasterxml.jackson.databind.SerializationFeature
+              import java.util.TimeZone
+
+              class Test {
+                  fun objectMapper(): ObjectMapper {
+                      return ObjectMapper()
+                              .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                              .setTimeZone(TimeZone.getDefault())
+                              .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                              .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                  }
+              }
+              """,
+            """
+              import com.fasterxml.jackson.annotation.JsonInclude
+              import tools.jackson.databind.ObjectMapper
+              import tools.jackson.databind.json.JsonMapper
+
+              import java.util.TimeZone
+
+              class Test {
+                  fun objectMapper(): ObjectMapper {
+                      return JsonMapper.builder()
+                          .defaultTimeZone(TimeZone.getDefault())
+                          .defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+                          .build()
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void updateSerializationInclusionOnBuilder() {
         rewriteRun(
           spec -> spec.recipe(new UpdateSerializationInclusionConfiguration()),

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -729,7 +729,7 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
         }
 
         @Test
-        void fluentChainWithUnknownMethodNoChange() {
+        void fluentChainWithTrailingNonSetterMethod() {
             rewriteRun(
               java(
                 """
@@ -740,6 +740,19 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
                       String create() {
                           return new JsonMapper()
                                   .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .writeValueAsString("test");
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      String create() {
+                          return JsonMapper.builder()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .build()
                                   .writeValueAsString("test");
                       }
                   }

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -588,6 +588,168 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
     }
 
     @Nested
+    class FluentChain {
+
+        @Test
+        void fluentChainReturnStatement() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          return new JsonMapper()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          return JsonMapper.builder()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void fluentChainFieldInitializer() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper mapper = new JsonMapper()
+                              .disable(SerializationFeature.INDENT_OUTPUT);
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper mapper = JsonMapper.builder()
+                              .disable(SerializationFeature.INDENT_OUTPUT)
+                              .build();
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void fluentChainWithSetTimeZone() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  import java.util.TimeZone;
+
+                  class A {
+                      JsonMapper create() {
+                          return new JsonMapper()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .setTimeZone(TimeZone.getDefault());
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  import java.util.TimeZone;
+
+                  class A {
+                      JsonMapper create() {
+                          return JsonMapper.builder()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .defaultTimeZone(TimeZone.getDefault())
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void fluentChainSetDefaultPropertyInclusionWithRawInclude() {
+            rewriteRun(
+              spec -> spec.parser(org.openrewrite.java.JavaParser.fromJavaVersion()
+                .classpath("jackson-core", "jackson-databind", "jackson-annotations")),
+              java(
+                """
+                  import com.fasterxml.jackson.annotation.JsonInclude;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  import java.util.TimeZone;
+
+                  class A {
+                      JsonMapper create() {
+                          return new JsonMapper()
+                                  .setTimeZone(TimeZone.getDefault())
+                                  .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.annotation.JsonInclude;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  import java.util.TimeZone;
+
+                  class A {
+                      JsonMapper create() {
+                          return JsonMapper.builder()
+                                  .defaultTimeZone(TimeZone.getDefault())
+                                  .defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void fluentChainWithUnknownMethodNoChange() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      String create() {
+                          return new JsonMapper()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .writeValueAsString("test");
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
+
+    @Nested
     class NoChange {
 
         @Test

--- a/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
@@ -327,9 +327,10 @@ class UpgradeJackson_2_3Test implements RewriteTest {
 
               class Test {
                   ObjectMapper objectMapper() {
-                      return new JsonMapper()
-                              .setTimeZone(TimeZone.getDefault())
-                              .setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL);
+                      return JsonMapper.builder()
+                              .defaultTimeZone(TimeZone.getDefault())
+                              .defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.NON_NULL))
+                              .build();
                   }
               }
               """


### PR DESCRIPTION
## Summary
- `MigrateMapperSettersToBuilder` now detects fluent chains on `new JsonMapper()` (e.g., `new JsonMapper().setTimeZone(...).registerModule(...)`) and converts them to `JsonMapper.builder()...build()`
- Adds special handling for `setDefaultPropertyInclusion(JsonInclude.Include.X)` to wrap with `JsonInclude.Value.construct(X, X)` since the builder expects a `Value`, not a raw `Include`
- Reorders recipes in `jackson-2-3.yml` so `RemoveRedundantFeatureFlags` and `RemoveBuiltInModuleRegistrations` run before builder migration, ensuring feature flags and built-in modules are removed from fluent chains first

## Test plan
- [x] Added 5 new unit tests for fluent chain scenarios (return statement, field initializer, setTimeZone, raw Include wrapping, unknown method no-change)
- [x] Updated `UpgradeJackson_2_3Test.chainedConfigurationOnNewObjectMapper` integration test expected output
- [x] All existing tests in `MigrateMapperSettersToBuilderTest`, `UpgradeJackson_2_3Test`, `KotlinUpgradeJackson_2_3Test`, `RemoveRedundantFeatureFlagsTest`, and `RemoveBuiltInModuleRegistrationsTest` pass

- Fixes https://github.com/openrewrite/rewrite-jackson/issues/89