### PR TITLE
Add missing Jackson 2→3 serializer/deserializer type changes

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -352,6 +352,12 @@ recipeList:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.module.afterburner.AfterburnerModule
       newFullyQualifiedTypeName: tools.jackson.module.blackbird.BlackbirdModule
   - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.databind.ser.std.JsonObjectSerializer
+      newFullyQualifiedTypeName: tools.jackson.databind.ser.std.ObjectValueSerializer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: com.fasterxml.jackson.databind.deser.std.JsonValueDeserializer
+      newFullyQualifiedTypeName: tools.jackson.databind.deser.std.ObjectValueDeserializer
+  - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: com.fasterxml.jackson.databind.PropertyNamingStrategy
       newFullyQualifiedTypeName: tools.jackson.databind.PropertyNamingStrategies
 


### PR DESCRIPTION
## Summary

- Add `ChangeType` mapping for `com.fasterxml.jackson.databind.ser.std.JsonObjectSerializer` → `tools.jackson.databind.ser.std.ObjectValueSerializer`
- Add `ChangeType` mapping for `com.fasterxml.jackson.databind.deser.std.JsonValueDeserializer` → `tools.jackson.databind.deser.std.ObjectValueDeserializer`

These types were renamed in Jackson 3.x but were missing from the `UpgradeJackson_2_3_TypeChanges` recipe.

## Test plan

- [x] Full `./gradlew build` passes including recipe CSV validation
- [ ] Verify CI passes on this branch