### PR TITLE
Use += instead of = for lombok.jacksonized.jacksonVersion config

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/LombokJacksonizedConfig.java
+++ b/src/main/java/org/openrewrite/java/jackson/LombokJacksonizedConfig.java
@@ -35,12 +35,12 @@ public class LombokJacksonizedConfig extends ScanningRecipe<LombokJacksonizedCon
 
     private static final String JACKSONIZED = "lombok.extern.jackson.Jacksonized";
     private static final String CONFIG_KEY = "lombok.jacksonized.jacksonVersion";
-    private static final String CONFIG_LINE = CONFIG_KEY + " = 3";
+    private static final String CONFIG_LINE = CONFIG_KEY + " += 3";
 
     String displayName = "Update `lombok.config` for Jackson 3 compatibility";
     String description = "When `@Jacksonized` is used, Lombok generates Jackson annotations. " +
             "By default it generates Jackson 2.x annotations. This recipe adds " +
-            "`lombok.jacksonized.jacksonVersion = 3` to `lombok.config` so Lombok generates " +
+            "`lombok.jacksonized.jacksonVersion += 3` to `lombok.config` so Lombok generates " +
             "Jackson 3 compatible annotations.";
 
     public static class Accumulator {

--- a/src/test/java/org/openrewrite/java/jackson/LombokJacksonizedConfigTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/LombokJacksonizedConfigTest.java
@@ -28,7 +28,7 @@ import static org.openrewrite.test.SourceSpecs.text;
 /**
  * Tests for gap: Lombok's {@code @Jacksonized} annotation generates Jackson 2.x annotations
  * by default. When migrating to Jackson 3, {@code lombok.config} must be updated to set
- * {@code lombok.jacksonized.jacksonVersion = 3}.
+ * {@code lombok.jacksonized.jacksonVersion += 3}.
  *
  * @see <a href="https://github.com/moderneinc/customer-requests/issues/1963">customer-requests#1963</a>
  */
@@ -69,7 +69,7 @@ class LombokJacksonizedConfigTest implements RewriteTest {
               """,
             """
               lombok.addLombokGeneratedAnnotation = true
-              lombok.jacksonized.jacksonVersion = 3
+              lombok.jacksonized.jacksonVersion += 3
               """,
             spec -> spec.path("lombok.config")
           )
@@ -97,7 +97,7 @@ class LombokJacksonizedConfigTest implements RewriteTest {
           text(
             doesNotExist(),
             """
-              lombok.jacksonized.jacksonVersion = 3
+              lombok.jacksonized.jacksonVersion += 3
               """,
             spec -> spec.path("lombok.config")
           )


### PR DESCRIPTION
## Summary
- Fixes #115: `lombok.jacksonized.jacksonVersion` is a list-type config key in Lombok, so using `=` produces a warning. This changes the recipe to use `+=` instead, which is the correct syntax for list-type Lombok config keys.
- Updates recipe description and test expectations to match.

## Test plan
- [x] `LombokJacksonizedConfigTest` passes (3 tests)