### PR TITLE
Rename getSerializationConfig/getDeserializationConfig for Jackson 3

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -73,6 +73,12 @@ recipeList:
   - org.openrewrite.java.AddCommentToMethodInvocations:
       methodPattern: "com.fasterxml.jackson.databind.ObjectMapper canDeserialize(..)"
       comment: "TODO canDeserialize was removed in Jackson 3 with no replacement (see https://github.com/FasterXML/jackson-databind/issues/1917). Attempt serialization/deserialization and catch exceptions instead."
+  - org.openrewrite.java.AddCommentToMethodInvocations:
+      methodPattern: "com.fasterxml.jackson.databind.ObjectMapper serializationConfig()"
+      comment: "TODO serializationConfig() is not to be used by application code in Jackson 3 (see https://github.com/FasterXML/jackson-databind/blob/3.x/src/main/java/tools/jackson/databind/ObjectMapper.java#L417). Consider using builder configuration instead."
+  - org.openrewrite.java.AddCommentToMethodInvocations:
+      methodPattern: "com.fasterxml.jackson.databind.ObjectMapper deserializationConfig()"
+      comment: "TODO deserializationConfig() is not to be used by application code in Jackson 3 (see https://github.com/FasterXML/jackson-databind/blob/3.x/src/main/java/tools/jackson/databind/ObjectMapper.java#L427). Consider using builder configuration instead."
   - org.openrewrite.java.jackson.UpgradeJackson_2_3_PackageChanges
   - org.openrewrite.java.jackson.SimplifyJacksonExceptionCatch
 
@@ -369,6 +375,12 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.databind.type.TypeFactory defaultInstance()
       newMethodName: createDefaultInstance
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.ObjectMapper getSerializationConfig()
+      newMethodName: serializationConfig
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.ObjectMapper getDeserializationConfig()
+      newMethodName: deserializationConfig
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
@@ -367,6 +367,93 @@ class Jackson3MethodRenamesTest implements RewriteTest {
     }
 
     @Test
+    void objectMapperGetSerializationConfig() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              import com.fasterxml.jackson.databind.SerializationConfig;
+
+              class Test {
+                  SerializationConfig test(ObjectMapper mapper) {
+                      return mapper.getSerializationConfig();
+                  }
+              }
+              """,
+            """
+              import tools.jackson.databind.ObjectMapper;
+              import tools.jackson.databind.SerializationConfig;
+
+              class Test {
+                  SerializationConfig test(ObjectMapper mapper) {
+                      return /* TODO serializationConfig() is not to be used by application code in Jackson 3 (see https://github.com/FasterXML/jackson-databind/blob/3.x/src/main/java/tools/jackson/databind/ObjectMapper.java#L417). Consider using builder configuration instead. */ mapper.serializationConfig();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void objectMapperGetDeserializationConfig() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.ObjectMapper;
+              import com.fasterxml.jackson.databind.DeserializationConfig;
+
+              class Test {
+                  DeserializationConfig test(ObjectMapper mapper) {
+                      return mapper.getDeserializationConfig();
+                  }
+              }
+              """,
+            """
+              import tools.jackson.databind.ObjectMapper;
+              import tools.jackson.databind.DeserializationConfig;
+
+              class Test {
+                  DeserializationConfig test(ObjectMapper mapper) {
+                      return /* TODO deserializationConfig() is not to be used by application code in Jackson 3 (see https://github.com/FasterXML/jackson-databind/blob/3.x/src/main/java/tools/jackson/databind/ObjectMapper.java#L427). Consider using builder configuration instead. */ mapper.deserializationConfig();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jsonMapperGetSerializationConfig() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.SerializationConfig;
+              import com.fasterxml.jackson.databind.json.JsonMapper;
+
+              class Test {
+                  SerializationConfig test(JsonMapper mapper) {
+                      return mapper.getSerializationConfig();
+                  }
+              }
+              """,
+            """
+              import tools.jackson.databind.SerializationConfig;
+              import tools.jackson.databind.json.JsonMapper;
+
+              class Test {
+                  SerializationConfig test(JsonMapper mapper) {
+                      return /* TODO serializationConfig() is not to be used by application code in Jackson 3 (see https://github.com/FasterXML/jackson-databind/blob/3.x/src/main/java/tools/jackson/databind/ObjectMapper.java#L417). Consider using builder configuration instead. */ mapper.serializationConfig();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void jsonNodeMethods() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## Summary
- Adds `ChangeMethodName` recipes to rename `getSerializationConfig()` → `serializationConfig()` and `getDeserializationConfig()` → `deserializationConfig()` for the Jackson 2→3 migration
- Adds `AddCommentToMethodInvocations` TODO comments warning that these methods are marked as not for application use in Jackson 3
- Adds tests covering `ObjectMapper` and `JsonMapper` scenarios

- Closes https://github.com/moderneinc/customer-requests/issues/2144