### PR TITLE
Preserve comments when migrating mapper setters to builder pattern

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -514,40 +514,23 @@ public class MigrateMapperSettersToBuilder extends Recipe {
             return result;
         }
 
-        // Check if any original setters carry comments
-        boolean hasComments = false;
-        for (J.MethodInvocation setter : originalSetters) {
-            if (!setter.getPrefix().getComments().isEmpty()) {
-                hasComments = true;
-                break;
-            }
-            if (setter.getPadding().getSelect() != null &&
-                    !setter.getPadding().getSelect().getAfter().getComments().isEmpty()) {
-                hasComments = true;
-                break;
-            }
-        }
-        if (!hasComments) {
-            return result;
-        }
-
-        // Flatten the result chain (outermost to innermost)
+        // Flatten result chain to innermost-first: [builder, setter_1, ..., setter_n, build, suffix...]
         List<J.MethodInvocation> chain = new ArrayList<>();
         Expression current = (Expression) result;
         while (current instanceof J.MethodInvocation) {
             chain.add((J.MethodInvocation) current);
             current = ((J.MethodInvocation) current).getSelect();
         }
-        // Reverse to innermost-first: [builder, setter_1, ..., setter_n, build, suffix...]
         reverse(chain);
 
-        // Attach comments from original setters to corresponding builder calls
+        // Comments live in different locations depending on syntax:
+        // - MI prefix for separate statements (mapper.disable(...))
+        // - select padding for fluent chains (new JsonMapper().disable(...))
+        boolean modified = false;
         for (int i = 0; i < originalSetters.size() && (i + 1) < chain.size(); i++) {
             J.MethodInvocation original = originalSetters.get(i);
             J.MethodInvocation target = chain.get(i + 1); // +1 to skip builder()
 
-            // Collect comments from both the prefix (separate statements) and
-            // select padding (fluent chains)
             List<Comment> comments = new ArrayList<>(original.getPrefix().getComments());
             if (original.getPadding().getSelect() != null) {
                 comments.addAll(original.getPadding().getSelect().getAfter().getComments());
@@ -556,21 +539,20 @@ public class MigrateMapperSettersToBuilder extends Recipe {
             if (!comments.isEmpty() && target.getPadding().getSelect() != null) {
                 JRightPadded<Expression> sel = target.getPadding().getSelect();
                 Space after = sel.getAfter();
-                // Adjust comment suffixes to match the builder chain indentation
+                // Reindent comment suffixes to match the builder chain context
                 String chainIndent = after.getWhitespace();
-                List<Comment> adjusted = new ArrayList<>();
-                for (Comment c : comments) {
-                    if (c instanceof TextComment) {
-                        adjusted.add(((TextComment) c).withSuffix(chainIndent));
-                    } else {
-                        adjusted.add(c);
-                    }
-                }
                 List<Comment> combined = new ArrayList<>(after.getComments());
-                combined.addAll(adjusted);
+                for (Comment c : comments) {
+                    combined.add(c instanceof TextComment ? ((TextComment) c).withSuffix(chainIndent) : c);
+                }
                 target = target.getPadding().withSelect(sel.withAfter(after.withComments(combined)));
                 chain.set(i + 1, target);
+                modified = true;
             }
+        }
+
+        if (!modified) {
+            return result;
         }
 
         // Rebuild the chain from innermost to outermost, propagating modifications
@@ -581,11 +563,10 @@ public class MigrateMapperSettersToBuilder extends Recipe {
             if (sel != null) {
                 mi = mi.getPadding().withSelect(sel.withElement(prev));
             }
-            chain.set(i, mi);
             prev = mi;
         }
 
-        return chain.get(chain.size() - 1);
+        return prev;
     }
 
     /**

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -494,14 +494,98 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             parser.dependsOn(mapperStub(mapperFqn));
                         }
 
-                        return JavaTemplate.builder(templateCode.toString())
+                        J result = JavaTemplate.builder(templateCode.toString())
                                 .imports(mapperFqn, JSON_INCLUDE)
                                 .javaParser(parser)
                                 .build()
                                 .apply(getCursor(), coordinates, templateArgs.toArray());
+                        return attachCommentsToBuilderChain(result, setters);
                     }
                 }
         );
+    }
+
+    /**
+     * Transfer comments from the original setter calls to the corresponding
+     * builder method calls in the generated builder chain.
+     */
+    private static J attachCommentsToBuilderChain(J result, List<J.MethodInvocation> originalSetters) {
+        if (!(result instanceof J.MethodInvocation)) {
+            return result;
+        }
+
+        // Check if any original setters carry comments
+        boolean hasComments = false;
+        for (J.MethodInvocation setter : originalSetters) {
+            if (!setter.getPrefix().getComments().isEmpty()) {
+                hasComments = true;
+                break;
+            }
+            if (setter.getPadding().getSelect() != null &&
+                    !setter.getPadding().getSelect().getAfter().getComments().isEmpty()) {
+                hasComments = true;
+                break;
+            }
+        }
+        if (!hasComments) {
+            return result;
+        }
+
+        // Flatten the result chain (outermost to innermost)
+        List<J.MethodInvocation> chain = new ArrayList<>();
+        Expression current = (Expression) result;
+        while (current instanceof J.MethodInvocation) {
+            chain.add((J.MethodInvocation) current);
+            current = ((J.MethodInvocation) current).getSelect();
+        }
+        // Reverse to innermost-first: [builder, setter_1, ..., setter_n, build, suffix...]
+        reverse(chain);
+
+        // Attach comments from original setters to corresponding builder calls
+        for (int i = 0; i < originalSetters.size() && (i + 1) < chain.size(); i++) {
+            J.MethodInvocation original = originalSetters.get(i);
+            J.MethodInvocation target = chain.get(i + 1); // +1 to skip builder()
+
+            // Collect comments from both the prefix (separate statements) and
+            // select padding (fluent chains)
+            List<Comment> comments = new ArrayList<>(original.getPrefix().getComments());
+            if (original.getPadding().getSelect() != null) {
+                comments.addAll(original.getPadding().getSelect().getAfter().getComments());
+            }
+
+            if (!comments.isEmpty() && target.getPadding().getSelect() != null) {
+                JRightPadded<Expression> sel = target.getPadding().getSelect();
+                Space after = sel.getAfter();
+                // Adjust comment suffixes to match the builder chain indentation
+                String chainIndent = after.getWhitespace();
+                List<Comment> adjusted = new ArrayList<>();
+                for (Comment c : comments) {
+                    if (c instanceof TextComment) {
+                        adjusted.add(((TextComment) c).withSuffix(chainIndent));
+                    } else {
+                        adjusted.add(c);
+                    }
+                }
+                List<Comment> combined = new ArrayList<>(after.getComments());
+                combined.addAll(adjusted);
+                target = target.getPadding().withSelect(sel.withAfter(after.withComments(combined)));
+                chain.set(i + 1, target);
+            }
+        }
+
+        // Rebuild the chain from innermost to outermost, propagating modifications
+        J.MethodInvocation prev = chain.get(0);
+        for (int i = 1; i < chain.size(); i++) {
+            J.MethodInvocation mi = chain.get(i);
+            JRightPadded<Expression> sel = mi.getPadding().getSelect();
+            if (sel != null) {
+                mi = mi.getPadding().withSelect(sel.withElement(prev));
+            }
+            chain.set(i, mi);
+            prev = mi;
+        }
+
+        return chain.get(chain.size() - 1);
     }
 
     /**

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -946,4 +946,87 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
             );
         }
     }
+
+    @Nested
+    class CommentPreservation {
+
+        @Test
+        void separateStatementCommentsPreserved() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          JsonMapper mapper = new JsonMapper();
+                          // Disable indentation for compact output
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          // Fail early on unexpected fields
+                          mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                          return mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          return JsonMapper.builder()
+                                  // Disable indentation for compact output
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  // Fail early on unexpected fields
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void fluentChainCommentsPreserved() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          return new JsonMapper()
+                                  // Disable indentation for compact output
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  // Fail early on unexpected fields
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          return JsonMapper.builder()
+                                  // Disable indentation for compact output
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  // Fail early on unexpected fields
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`MigrateMapperSettersToBuilder` drops comments from original code when converting `ObjectMapper` setter calls to the builder pattern. This affects both separate statement setters and fluent chains.

## Solution

After `JavaTemplate.apply()` generates the new builder chain, transfer comments from the original setter calls to the corresponding builder method calls. Comment suffixes are adjusted to match the indentation of the builder chain context.