### PR TITLE
Preserve comments when migrating setters to builder

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -716,6 +716,13 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         mi.getArguments().get(0).getType())) {
             builderName = "serializationInclusion";
         }
+        // Preserve comments from the original setter invocation (statement-level prefix
+        // for separate-statement setters, method name or select padding for fluent chain calls)
+        appendComments(mi.getPrefix().getComments(), templateCode);
+        appendComments(mi.getName().getPrefix().getComments(), templateCode);
+        if (mi.getPadding().getSelect() != null) {
+            appendComments(mi.getPadding().getSelect().getAfter().getComments(), templateCode);
+        }
         templateCode.append("\n.").append(builderName).append("(");
         boolean first = true;
         for (Expression arg : mi.getArguments()) {
@@ -730,5 +737,19 @@ public class MigrateMapperSettersToBuilder extends Recipe {
             templateArgs.add(arg);
         }
         templateCode.append(")");
+    }
+
+    private static void appendComments(List<Comment> comments, StringBuilder templateCode) {
+        for (Comment comment : comments) {
+            if (comment instanceof TextComment) {
+                TextComment tc = (TextComment) comment;
+                if (tc.isMultiline()) {
+                    templateCode.append("\n/*").append(tc.getText()).append("*/");
+                } else {
+                    // Leading space before // so the auto-formatter indents the comment line
+                    templateCode.append("\n //").append(tc.getText());
+                }
+            }
+        }
     }
 }

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -716,8 +716,6 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         mi.getArguments().get(0).getType())) {
             builderName = "serializationInclusion";
         }
-        // Preserve comments from the original setter invocation (statement-level prefix
-        // for separate-statement setters, method name or select padding for fluent chain calls)
         appendComments(mi.getPrefix().getComments(), templateCode);
         appendComments(mi.getName().getPrefix().getComments(), templateCode);
         if (mi.getPadding().getSelect() != null) {

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -374,6 +374,172 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
     }
 
     @Nested
+    class CommentPreservation {
+
+        @Test
+        void commentsOnSettersPreserved() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          JsonMapper mapper = new JsonMapper();
+                          // Disable indentation
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          // Fail on unknown
+                          mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                          return mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          return JsonMapper.builder()
+                                  // Disable indentation
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  // Fail on unknown
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void blockCommentsOnSettersPreserved() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          JsonMapper mapper = new JsonMapper();
+                          /* Disable indentation */
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          /* Fail on unknown */
+                          mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                          return mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          return JsonMapper.builder()
+                                  /* Disable indentation */
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  /* Fail on unknown */
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void commentsPreservedOnFieldAssignment() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper mapper;
+
+                      void configure() {
+                          mapper = new JsonMapper();
+                          // Disable indentation
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          // Fail on unknown
+                          mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper mapper;
+
+                      void configure() {
+                          mapper = JsonMapper.builder()
+                                  // Disable indentation
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  // Fail on unknown
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void fluentChainCommentsPreserved() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          return new JsonMapper()
+                                  // Disable indentation
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  // Fail on unknown
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          return JsonMapper.builder()
+                                  // Disable indentation
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  // Fail on unknown
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
+
+    @Nested
     class CommentFallback {
 
         @Test


### PR DESCRIPTION
## Summary
- Comments (line and block) on setter method invocations were being dropped when `MigrateMapperSettersToBuilder` folded them into the `JsonMapper.builder()...build()` chain.
- Embeds comments directly in the JavaTemplate string in `appendBuilderCall`, collecting them from three AST locations: statement prefix, method name prefix, and select padding (for fluent chains).
- Adds a new `appendComments` helper that renders `TextComment` nodes as line or block comments with proper formatting for auto-indentation.

- Closes https://github.com/moderneinc/customer-requests/issues/2154

## Test plan
- [x] `commentsOnSettersPreserved` — line comments on statement-level setters
- [x] `blockCommentsOnSettersPreserved` — block comments on statement-level setters
- [x] `commentsPreservedOnFieldAssignment` — comments on field assignment setters
- [x] `fluentChainCommentsPreserved` — comments in fluent chains
- [x] All existing tests continue to pass