### PR TITLE
Stop folding non-setter methods into ObjectMapper builder

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -310,6 +310,18 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                 TypeUtils.isOfType(sel.getType(), varIdent.getType());
                     }
 
+                    private boolean isSetterReturnType(J.MethodInvocation mi) {
+                        JavaType.Method methodType = mi.getMethodType();
+                        if (methodType == null) {
+                            return false;
+                        }
+                        JavaType returnType = methodType.getReturnType();
+                        if (returnType == JavaType.Primitive.Void) {
+                            return true;
+                        }
+                        return TypeUtils.isAssignableTo("com.fasterxml.jackson.databind.ObjectMapper", returnType);
+                    }
+
                     private boolean referencesVariable(Statement stmt, J.Identifier varIdent) {
                         return !new JavaIsoVisitor<Set<Boolean>>() {
                             @Override
@@ -485,6 +497,11 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                             collecting = false;
                                             continue;
                                         }
+                                        if (SetterToBuilderMapping.fromSetter(initMi.getName().getSimpleName()) == null &&
+                                                !isSetterReturnType(initMi)) {
+                                            collecting = false;
+                                            continue;
+                                        }
                                         setters.add(initMi);
                                         continue;
                                     }
@@ -499,6 +516,11 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             J.MethodInvocation mi = extractMethodInvocation(stmt);
                             if (mi != null && isCallOnVariable(mi, varIdent)) {
                                 if (argumentReferencesAny(mi, intermediateVars)) {
+                                    collecting = false;
+                                    continue;
+                                }
+                                if (SetterToBuilderMapping.fromSetter(mi.getName().getSimpleName()) == null &&
+                                        !isSetterReturnType(mi)) {
                                     collecting = false;
                                     continue;
                                 }

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.jackson;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -1175,6 +1176,80 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
                                   .disable(SerializationFeature.INDENT_OUTPUT)
                                   .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(JsonInclude.Include.NON_NULL).withValueInclusion(JsonInclude.Include.NON_NULL))
                                   .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
+
+    @Nested
+    class NonSetterMethodsNotFolded {
+
+        @Issue("https://github.com/moderneinc/customer-requests/issues/2225")
+        @Test
+        void readValueNotFoldedIntoBuilder() {
+            rewriteRun(
+              java(
+                """
+                  import java.io.InputStream;
+                  import java.util.List;
+                  import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.Module;
+
+                  class A {
+                      List<Object> read(InputStream inputStream, Module module) throws Exception {
+                          JsonMapper mapper = new JsonMapper();
+                          mapper.registerModule(module);
+                          mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+                          List<Object> l = mapper.readValue(inputStream, List.class);
+                          return l;
+                      }
+                  }
+                  """,
+                """
+                  import java.io.InputStream;
+                  import java.util.List;
+                  import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.Module;
+
+                  class A {
+                      List<Object> read(InputStream inputStream, Module module) throws Exception {
+                          JsonMapper mapper = JsonMapper.builder()
+                                  .addModule(module)
+                                  .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                                  .build();
+                          return mapper.readValue(inputStream, List.class);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite-jackson/issues/130")
+        @Test
+        void writeValueAsStringNotFoldedIntoBuilder() {
+            rewriteRun(
+              java(
+                """
+                  import java.util.Map;
+                  import com.fasterxml.jackson.core.JsonProcessingException;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      String convert(Map<String, Object> customPropertyMap) {
+                          JsonMapper mapper = new JsonMapper();
+                          String customProperties;
+                          try {
+                              customProperties = mapper.writeValueAsString(customPropertyMap);
+                          } catch (JsonProcessingException ex) {
+                              throw new RuntimeException(ex);
+                          }
+                          return customProperties;
                       }
                   }
                   """

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -1238,11 +1238,11 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
                 """
                   import java.util.Map;
                   import com.fasterxml.jackson.core.JsonProcessingException;
-                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
 
                   class A {
                       String convert(Map<String, Object> customPropertyMap) {
-                          ObjectMapper mapper = new ObjectMapper();
+                          JsonMapper mapper = new JsonMapper();
                           String customProperties;
                           try {
                               customProperties = mapper.writeValueAsString(customPropertyMap);

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -1238,11 +1238,11 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
                 """
                   import java.util.Map;
                   import com.fasterxml.jackson.core.JsonProcessingException;
-                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
 
                   class A {
                       String convert(Map<String, Object> customPropertyMap) {
-                          JsonMapper mapper = new JsonMapper();
+                          ObjectMapper mapper = new ObjectMapper();
                           String customProperties;
                           try {
                               customProperties = mapper.writeValueAsString(customPropertyMap);


### PR DESCRIPTION
## Summary
- `MigrateMapperSettersToBuilder` was incorrectly collecting operational methods like `readValue()` and `writeValueAsString()` as standalone setters, folding them into the builder chain and corrupting code
- Added a return type check in `collectStandaloneSetters`: unknown methods (not in `SetterToBuilderMapping`) that don't return `void` or an `ObjectMapper`-assignable type stop collection. Known setters are always collected regardless of return type
- Added tests for both reported scenarios

- Closes https://github.com/moderneinc/customer-requests/issues/2225
- Closes https://github.com/openrewrite/rewrite-jackson/issues/130

## Test plan
- [x] Existing tests pass (31 Java + Kotlin tests)
- [x] New test: `readValueNotFoldedIntoBuilder` — setters folded, `readValue` assignment preserved
- [x] New test: `writeValueAsStringNotFoldedIntoBuilder` — no setters, no change, `writeValueAsString` in try block untouched