### PR TITLE
Target Jackson 3.1.x in UpgradeJackson_2_3 recipe

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -102,152 +102,152 @@ recipeList:
       oldArtifactId: jackson-core
       newGroupId: tools.jackson.core
       newArtifactId: jackson-core
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson
       oldArtifactId: jackson-bom
       newGroupId: tools.jackson
       newArtifactId: jackson-bom
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.core
       oldArtifactId: jackson-databind
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-parameter-names
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-scala_2.13
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-scala_2.13
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-scala_2.12
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-scala_2.12
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-scala_3
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-scala_3
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-kotlin
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-kotlin
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-no-ctor-deser
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-no-ctor-deser
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-jakarta-xmlbind-annotations
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-jakarta-xmlbind-annotations
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-mrbean
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-mrbean
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-jaxb-annotations
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-jaxb-annotations
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-afterburner
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-afterburner
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-guice7
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-guice7
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-modules-base
       newGroupId: tools.jackson.module
       newArtifactId: jackson-modules-base
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-osgi
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-osgi
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-guice
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-guice
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-android-record
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-android-record
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.module
       oldArtifactId: jackson-module-blackbird
       newGroupId: tools.jackson.module
       newArtifactId: jackson-module-blackbird
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.dataformat
       oldArtifactId: "*"
       newGroupId: tools.jackson.dataformat
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.datatype
       oldArtifactId: jackson-datatype-jdk8
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.datatype
       oldArtifactId: jackson-datatype-jsr310
       newGroupId: tools.jackson.core
       newArtifactId: jackson-databind
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.datatype
       oldArtifactId: jackson-datatype-*
       newGroupId: tools.jackson.datatype
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.jaxrs
       oldArtifactId: "*"
       newGroupId: tools.jackson.jaxrs
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.jakarta.rs
       oldArtifactId: "*"
       newGroupId: tools.jackson.jakarta.rs
-      newVersion: 3.0.x
+      newVersion: 3.1.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: com.fasterxml.jackson.jr
       oldArtifactId: "*"
       newGroupId: tools.jackson.jr
-      newVersion: 3.0.x
+      newVersion: 3.1.x
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
+++ b/src/test/java/org/openrewrite/java/jackson/UpgradeJackson_2_3Test.java
@@ -87,7 +87,7 @@ class UpgradeJackson_2_3Test implements RewriteTest {
               """,
             spec -> spec.after(pom -> {
                 Matcher versionMatcher = Pattern.compile("3\\.\\d+\\.\\d+").matcher(pom);
-                assertThat(versionMatcher.find()).describedAs("Expected 3.0.x in %s", pom).isTrue();
+                assertThat(versionMatcher.find()).describedAs("Expected 3.1.x in %s", pom).isTrue();
                 String jacksonVersion = versionMatcher.group(0);
 
                 //language=xml


### PR DESCRIPTION
## Summary

- Retarget `UpgradeJackson_2_3_Dependencies` to `newVersion: 3.1.x` (26 entries) so consumers land on the Jackson 3.1 LTS line that matches the `jackson-bom` 3.1.2 managed by the Spring Boot 4.0.5 BOM. Reported via [moderneinc/customer-requests#2290](https://github.com/moderneinc/customer-requests/issues/2290).
- Update the cosmetic `describedAs` label in `UpgradeJackson_2_3Test` to `"Expected 3.1.x in %s"`. The version regex (`3\.\d+\.\d+`) was already minor-agnostic and is unchanged; every other version assertion in the test suite uses the same regex.
- `jackson-annotations` stays pinned at `2.21` — annotations did not move to a 3.x line in Jackson 3.1.

## Why a version bump is sufficient

Jackson 3.1.0 (released 2026-02-23, LTS) introduces **no** type renames or method renames vs 3.0. The differences are behavior shifts and additive APIs (`@JsonDeserializeAs`, `JsonNode.map()`, `MapperFeature.WRAPPERS_DEFAULT_TO_NULL`, etc.). No new `ChangeType` / `ChangeMethodName` / `AddCommentToMethodInvocations` entries are warranted.

## Behavior changes consumers should be aware of (3.0 → 3.1)

These are documented release-note risks; none have a clean enough call-site fingerprint to justify a static rewrite without significant false-positive noise. Surfacing them here so downstream callers (e.g. `UpgradeSpringBoot_4_0` in rewrite-spring) and release notes can pass them along:

- **`AtomicReference` deserialization:** missing JSON now yields `AtomicReference<>(null)` instead of `null`. Opt out via `DeserializationFeature.USE_NULL_FOR_MISSING_REFERENCE_VALUES`.
- **`StreamReadConstraints.maxStringLength`:** default raised 20 MB → 100 MB.
- **`JsonNode.asXxx(default)` / `asXxxOpt()`:** `NullNode` is now treated like a missing node (returns the default).
- **JAX-RS / Jakarta-RS providers:** stop matching empty / missing `Content-Type` by default. Restore old behavior via `JaxRSFeature.MATCH_ALL_IF_NO_MEDIA_TYPE` or `JakartaRSFeature.MATCH_ALL_IF_NO_MEDIA_TYPE`.

## Test plan

- [x] `./gradlew test --tests UpgradeJackson_2_3Test --tests Jackson3DependenciesTest` — green; confirms 3.1.x resolves on Maven Central and is accepted by the existing regex.
- [x] `./gradlew test` (full suite) — green; no incidental regressions.
- [x] Verified no other source/test files hardcoded `3.0.x` (only the 26 YAML lines + 1 cosmetic test message).