### PR TITLE
Rename JsonParser getCurrentToken/getCurrentName for Jackson 3

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -502,6 +502,12 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.core.JsonParser nextTextValue()
       newMethodName: nextStringValue
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.core.JsonParser getCurrentToken()
+      newMethodName: currentToken
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.core.JsonParser getCurrentName()
+      newMethodName: currentName
 
 # Based on https://github.com/FasterXML/jackson-future-ideas/wiki/JSTEP-3
 

--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -413,6 +413,18 @@ tags:
   - jackson-3
 recipeList:
   - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.core.JsonGenerator getOutputContext()
+      newMethodName: streamWriteContext
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.core.JsonGenerator getOutputTarget()
+      newMethodName: streamWriteOutputTarget
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.core.JsonGenerator getOutputBuffered()
+      newMethodName: streamWriteOutputBuffered
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.core.JsonGenerator canOmitFields()
+      newMethodName: canOmitProperties
+  - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.core.JsonGenerator getCodec()
       newMethodName: objectWriteContext
   - org.openrewrite.java.ChangeMethodName:
@@ -472,6 +484,15 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.core.JsonParser getCodec()
       newMethodName: objectReadContext
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.core.JsonParser getParsingContext()
+      newMethodName: streamReadContext
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.core.JsonParser getInputSource()
+      newMethodName: streamReadInputSource
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.core.JsonParser nextFieldName(..)
+      newMethodName: nextName
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.core.JsonParser getCurrentLocation()
       newMethodName: currentLocation

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
@@ -330,6 +330,62 @@ class Jackson3MethodRenamesTest implements RewriteTest {
     }
 
     @Test
+    void jsonParserGetCurrentToken() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonParser;
+              import com.fasterxml.jackson.core.JsonToken;
+
+              class Test {
+                  JsonToken test(JsonParser parser) throws Exception {
+                      return parser.getCurrentToken();
+                  }
+              }
+              """,
+            """
+              import tools.jackson.core.JsonParser;
+              import tools.jackson.core.JsonToken;
+
+              class Test {
+                  JsonToken test(JsonParser parser) throws Exception {
+                      return parser.currentToken();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jsonParserGetCurrentName() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonParser;
+
+              class Test {
+                  String test(JsonParser parser) throws Exception {
+                      return parser.getCurrentName();
+                  }
+              }
+              """,
+            """
+              import tools.jackson.core.JsonParser;
+
+              class Test {
+                  String test(JsonParser parser) throws Exception {
+                      return parser.currentName();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void jsonParserTextMethods() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
@@ -115,6 +115,59 @@ class Jackson3MethodRenamesTest implements RewriteTest {
     }
 
     @Test
+    void jsonGeneratorLegacyAccessorMethods() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonGenerator;
+              import com.fasterxml.jackson.core.JsonStreamContext;
+
+              class Test {
+                  JsonStreamContext context(JsonGenerator gen) {
+                      return gen.getOutputContext();
+                  }
+
+                  Object target(JsonGenerator gen) {
+                      return gen.getOutputTarget();
+                  }
+
+                  int buffered(JsonGenerator gen) {
+                      return gen.getOutputBuffered();
+                  }
+
+                  boolean canOmit(JsonGenerator gen) {
+                      return gen.canOmitFields();
+                  }
+              }
+              """,
+            """
+              import tools.jackson.core.JsonGenerator;
+              import tools.jackson.core.TokenStreamContext;
+
+              class Test {
+                  TokenStreamContext context(JsonGenerator gen) {
+                      return gen.streamWriteContext();
+                  }
+
+                  Object target(JsonGenerator gen) {
+                      return gen.streamWriteOutputTarget();
+                  }
+
+                  int buffered(JsonGenerator gen) {
+                      return gen.streamWriteOutputBuffered();
+                  }
+
+                  boolean canOmit(JsonGenerator gen) {
+                      return gen.canOmitProperties();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void jsonGeneratorSetCurrentValue() {
         rewriteRun(
           //language=java
@@ -351,6 +404,61 @@ class Jackson3MethodRenamesTest implements RewriteTest {
               class Test {
                   JsonToken test(JsonParser parser) throws Exception {
                       return parser.currentToken();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void jsonParserLegacyAccessorMethods() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.core.JsonParser;
+              import com.fasterxml.jackson.core.JsonStreamContext;
+              import com.fasterxml.jackson.core.SerializableString;
+
+              class Test {
+                  JsonStreamContext context(JsonParser parser) {
+                      return parser.getParsingContext();
+                  }
+
+                  Object inputSource(JsonParser parser) {
+                      return parser.getInputSource();
+                  }
+
+                  String nextFieldName(JsonParser parser) throws Exception {
+                      return parser.nextFieldName();
+                  }
+
+                  boolean nextFieldName(JsonParser parser, SerializableString name) throws Exception {
+                      return parser.nextFieldName(name);
+                  }
+              }
+              """,
+            """
+              import tools.jackson.core.JsonParser;
+              import tools.jackson.core.SerializableString;
+              import tools.jackson.core.TokenStreamContext;
+
+              class Test {
+                  TokenStreamContext context(JsonParser parser) {
+                      return parser.streamReadContext();
+                  }
+
+                  Object inputSource(JsonParser parser) {
+                      return parser.streamReadInputSource();
+                  }
+
+                  String nextFieldName(JsonParser parser) throws Exception {
+                      return parser.nextName();
+                  }
+
+                  boolean nextFieldName(JsonParser parser, SerializableString name) throws Exception {
+                      return parser.nextName(name);
                   }
               }
               """


### PR DESCRIPTION
## Summary
Add missing Jackson 2->3 method rename mappings for `JsonParser` in the migration recipe:
- `getCurrentToken()` -> `currentToken()`
- `getCurrentName()` -> `currentName()`

## Changes
- Updated `UpgradeJackson_2_3_JsonParserMethodRenames` in `src/main/resources/META-INF/rewrite/jackson-2-3.yml`
- Added regression tests in `src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java`:
  - `jsonParserGetCurrentToken`
  - `jsonParserGetCurrentName`

## Validation
- Ran targeted tests for the new scenarios and they pass.

- Related to moderneinc/customer-requests#2354.