### PR TITLE
Handle jackson-core and jackson-databind resolving to different versions

### DIFF
--- a/src/test/java/org/openrewrite/java/jackson/codehaus/CodehausDependencyToFasterXMLTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/codehaus/CodehausDependencyToFasterXMLTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
 import java.util.regex.Pattern;
 
 import static org.openrewrite.maven.Assertions.pomXml;
@@ -55,7 +56,11 @@ class CodehausDependencyToFasterXMLTest implements RewriteTest {
               </project>
               """,
             after -> after.after(pomXml -> {
-                String version = Pattern.compile("<version>(2\\.\\d+\\.\\d+)</version>").matcher(pomXml).results().findFirst().get().group(1);
+                // jackson-core and jackson-databind resolve independently to their own latest
+                // release, which may differ when Jackson publishes the modules at different times.
+                List<String> versions = Pattern.compile("<version>(2\\.\\d+\\.\\d+)</version>").matcher(pomXml).results()
+                  .map(result -> result.group(1))
+                  .toList();
                 return """
                   <project>
                       <modelVersion>4.0.0</modelVersion>
@@ -71,11 +76,11 @@ class CodehausDependencyToFasterXMLTest implements RewriteTest {
                           <dependency>
                               <groupId>com.fasterxml.jackson.core</groupId>
                               <artifactId>jackson-databind</artifactId>
-                              <version>%1$s</version>
+                              <version>%2$s</version>
                           </dependency>
                       </dependencies>
                   </project>
-                  """.formatted(version);
+                  """.formatted(versions.get(0), versions.get(1));
             })
           )
         );


### PR DESCRIPTION
## Problem

Scheduled CI started failing on 2026-06-01 ([run 26783350232](https://github.com/openrewrite/rewrite-jackson/actions/runs/26783350232)):

```
CodehausDependencyToFasterXMLTest > changeDependencyWithoutExplicitVersion() FAILED
  AssertionFailedError: Unexpected result in "pom.xml":
  -            <version>2.21.4</version>   (jackson-databind, expected)
  +            <version>2.22.0</version>   (jackson-databind, actual)
```

## Root cause

Not an upstream API break — this is **version drift from a partial Jackson publication**. The test migrates two codehaus dependencies to `com.fasterxml.jackson.core:jackson-core` and `jackson-databind` without an explicit version, then captured the **first** `2.x.y` version it found in the output and asserted **both** dependencies used that same value:

```java
String version = Pattern.compile("<version>(2\\.\\d+\\.\\d+)</version>").matcher(pomXml).results().findFirst().get().group(1);
... .formatted(version); // applied to both jackson-core and jackson-databind
```

When Jackson publishes its modules at different times (here **jackson-databind 2.22.0** was released ahead of **jackson-core 2.21.4**), each artifact resolves independently to its own latest release, so the two versions legitimately differ and the single-version assumption breaks.

## Fix

Capture each resolved version independently rather than assuming the modules share a version. Full `./gradlew test` passes locally.

## Note

The same partial-Jackson-publication is rippling through other recipe repos' scheduled CI today (e.g. `rewrite-prethink` couldn't resolve the unpublished `jackson-dataformat-*:2.23.0-SNAPSHOT`). This change just makes the test robust to it.