### PR TITLE
Rename `JsonMappingException.Reference.getFieldName()` to `getPropertyName()`

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -409,6 +409,9 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.databind.ObjectMapper getDeserializationConfig()
       newMethodName: deserializationConfig
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: com.fasterxml.jackson.databind.JsonMappingException.Reference getFieldName()
+      newMethodName: getPropertyName
 
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
@@ -718,6 +718,35 @@ class Jackson3MethodRenamesTest implements RewriteTest {
     }
 
     @Test
+    void referenceGetFieldName() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+              class Test {
+                  String test(InvalidFormatException ife) {
+                      return ife.getPath().isEmpty() ? "unknown" :
+                          ife.getPath().get(ife.getPath().size() - 1).getFieldName();
+                  }
+              }
+              """,
+            """
+              import tools.jackson.databind.exc.InvalidFormatException;
+
+              class Test {
+                  String test(InvalidFormatException ife) {
+                      return ife.getPath().isEmpty() ? "unknown" :
+                          ife.getPath().get(ife.getPath().size() - 1).getPropertyName();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void objectNodePutJsonNode() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## What's changed

Adds a `ChangeMethodName` to the Jackson 2.x → 3.x method renames recipe for `JsonMappingException.Reference.getFieldName()` → `getPropertyName()`.

## Why

In Jackson 3, the `Reference` accessor `getFieldName()` was renamed to `getPropertyName()` (the field now lives on `tools.jackson.core.JacksonException.Reference`). This is part of the project-wide `field` → `property` renaming that the recipe already handles elsewhere — e.g. `JsonToken.FIELD_NAME` → `PROPERTY_NAME`, `JsonGenerator.writeFieldName()` → `writeName()`, `JsonParser.nextFieldName()` → `nextName()`.

Code that extracts the offending property name from a deserialization error path — e.g.

```java
ife.getPath().get(ife.getPath().size() - 1).getFieldName()
```

currently fails to compile after migration because `getFieldName()` no longer exists. The new rename keeps this path-based extraction working (and behavior-preserving) by mapping it to `getPropertyName()`.

The entry lives in `UpgradeJackson_2_3_MethodRenames`, which runs before `UpgradeJackson_2_3_TypeChanges`/`PackageChanges`, so the pattern correctly targets the Jackson 2 type `com.fasterxml.jackson.databind.JsonMappingException.Reference`.

## Testing

Added `referenceGetFieldName` to `Jackson3MethodRenamesTest`, exercising the realistic `InvalidFormatException.getPath()` usage end-to-end through the full `UpgradeJackson_2_3` recipe.

