### PR TITLE
Rename JsonNode `textValue()` to `stringValue()` instead of `asString()`

### DIFF
--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -573,7 +573,7 @@ recipeList:
       matchOverrides: true
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.databind.JsonNode textValue()
-      newMethodName: asString
+      newMethodName: stringValue
       matchOverrides: true
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: com.fasterxml.jackson.databind.JsonNode with(..)

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
@@ -657,7 +657,7 @@ class Jackson3MethodRenamesTest implements RewriteTest {
                       List<String> textValues = node.findValuesAsString("mango");
                       boolean isContainer = node.isContainer();
                       boolean isString = node.isString();
-                      String textValue = node.asString();
+                      String textValue = node.stringValue();
                       var modifiedNode = node.withObject("pineapple");
                   }
               }
@@ -708,7 +708,7 @@ class Jackson3MethodRenamesTest implements RewriteTest {
                       List<String> textValues = node.findValuesAsString("mango");
                       boolean isContainer = node.isContainer();
                       boolean isString = node.isString();
-                      String textValue = node.asString();
+                      String textValue = node.stringValue();
                       var modifiedNode = node.withObject("pineapple");
                   }
               }

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
@@ -718,6 +718,37 @@ class Jackson3MethodRenamesTest implements RewriteTest {
     }
 
     @Test
+    void jsonNodeAsTextVersusTextValue() {
+        // asText() coerces (null node -> ""), textValue() does not (null node -> null);
+        // Jackson 3 preserves this distinction as asString() and stringValue(). See gh-144.
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import com.fasterxml.jackson.databind.JsonNode;
+
+              class Test {
+                  void test(JsonNode node) {
+                      String coerced = node.asText();
+                      String exact = node.textValue();
+                  }
+              }
+              """,
+            """
+              import tools.jackson.databind.JsonNode;
+
+              class Test {
+                  void test(JsonNode node) {
+                      String coerced = node.asString();
+                      String exact = node.stringValue();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void referenceGetFieldName() {
         rewriteRun(
           //language=java

--- a/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/Jackson3MethodRenamesTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.jackson;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -717,6 +718,7 @@ class Jackson3MethodRenamesTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-jackson/issues/144")
     @Test
     void jsonNodeAsTextVersusTextValue() {
         // asText() coerces (null node -> ""), textValue() does not (null node -> null);


### PR DESCRIPTION
- Fixes #144

In Jackson 2, `JsonNode.asText()` and `JsonNode.textValue()` have different null semantics:
- `asText()` coerces to a text representation (a null node returns `"null"`)
- `textValue()` returns the actual text content only for textual nodes, otherwise `null`

Jackson 3 preserves this distinction with `asString()` and `stringValue()` respectively. The recipe previously mapped both `asText()` and `textValue()` to `asString()`, silently changing behavior for callers of `textValue()`.

This maps `textValue()` → `stringValue()` and updates the test accordingly.