### PR TITLE
Fix RemoveRedundantFeatureFlags deleting parenthesized builder chains

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlags.java
+++ b/src/main/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlags.java
@@ -109,14 +109,24 @@ public class RemoveRedundantFeatureFlags extends Recipe {
                     public @Nullable J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                         if (shouldRemove(method)) {
                             maybeRemoveFeatureImport(method.getArguments().get(0));
-                            // If it's part of a chain (method call or new X()), return the select; otherwise remove the statement
-                            if (method.getSelect() instanceof J.MethodInvocation || method.getSelect() instanceof J.NewClass) {
-                                J visited = visit(method.getSelect(), ctx);
+                            // If it's part of a chain (method call or new X(), possibly parenthesized),
+                            // return the select; otherwise remove the statement
+                            Expression select = unwrapParentheses(method.getSelect());
+                            if (select instanceof J.MethodInvocation || select instanceof J.NewClass) {
+                                J visited = visit(select, ctx);
                                 return visited != null ? visited.withPrefix(method.getPrefix()) : null;
                             }
                             return null;
                         }
                         return super.visitMethodInvocation(method, ctx);
+                    }
+
+                    private @Nullable Expression unwrapParentheses(@Nullable Expression select) {
+                        while (select instanceof J.Parentheses) {
+                            J tree = ((J.Parentheses<?>) select).getTree();
+                            select = tree instanceof Expression ? (Expression) tree : null;
+                        }
+                        return select;
                     }
 
                     private void maybeRemoveFeatureImport(Expression arg) {

--- a/src/main/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlags.java
+++ b/src/main/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlags.java
@@ -111,7 +111,7 @@ public class RemoveRedundantFeatureFlags extends Recipe {
                             maybeRemoveFeatureImport(method.getArguments().get(0));
                             // If it's part of a chain (method call or new X(), possibly parenthesized),
                             // return the select; otherwise remove the statement
-                            Expression select = unwrapParentheses(method.getSelect());
+                            Expression select = Expression.unwrap(method.getSelect());
                             if (select instanceof J.MethodInvocation || select instanceof J.NewClass) {
                                 J visited = visit(select, ctx);
                                 return visited != null ? visited.withPrefix(method.getPrefix()) : null;
@@ -119,14 +119,6 @@ public class RemoveRedundantFeatureFlags extends Recipe {
                             return null;
                         }
                         return super.visitMethodInvocation(method, ctx);
-                    }
-
-                    private @Nullable Expression unwrapParentheses(@Nullable Expression select) {
-                        while (select instanceof J.Parentheses) {
-                            J tree = ((J.Parentheses<?>) select).getTree();
-                            select = tree instanceof Expression ? (Expression) tree : null;
-                        }
-                        return select;
                     }
 
                     private void maybeRemoveFeatureImport(Expression arg) {

--- a/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/RemoveRedundantFeatureFlagsTest.java
@@ -575,6 +575,46 @@ class RemoveRedundantFeatureFlagsTest implements RewriteTest {
             );
         }
         @Test
+        void removeConfigureInParenthesizedChain() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.MapperFeature;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      private static ObjectMapper createJsonObjectMapper() {
+                          return ((((JsonMapper.builder()
+                                  .findAndAddModules()).configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false))
+                                  .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true))
+                                  .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)).build();
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.MapperFeature;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Test {
+                      private static ObjectMapper createJsonObjectMapper() {
+                          return (((JsonMapper.builder()
+                                  .findAndAddModules())
+                                  .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true))
+                                  .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)).build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void removeMultipleChainedRedundantFlags() {
             rewriteRun(
               //language=java


### PR DESCRIPTION
- Fixes #146
- Closes #147 

## Problem

When a redundant feature flag method call (such as `configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)`) appeared in a chain whose receiver was wrapped in parentheses, `RemoveRedundantFeatureFlags` only recognized a `J.MethodInvocation` or `J.NewClass` select. A parenthesized select (`J.Parentheses`) fell through to `return null`, deleting the **entire** receiver chain and producing uncompilable code:

```java
return (((
        .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true))
        .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)).build();
```

## Fix

Unwrap `J.Parentheses` before deciding whether the call is part of a chain, and return the unwrapped select. This both preserves the chain and cleans up the now-redundant parentheses left behind by the removed call.

Added a regression test (`removeConfigureInParenthesizedChain`) reproducing the exact case from the issue.