### PR TITLE
Fold setters that reference intermediate variables into builder

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -220,8 +220,10 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         }
 
                         // Collect setter calls that appear after the constructor
+                        List<Statement> movableStmts = new ArrayList<>();
+                        boolean[] setterUsesIntermediate = {false};
                         List<J.MethodInvocation> builderSetters = collectStandaloneSetters(
-                                block, varIdent, new HashSet<>());
+                                block, varIdent, new HashSet<>(), movableStmts, setterUsesIntermediate);
 
                         if (builderSetters.isEmpty()) {
                             return nc;
@@ -236,6 +238,25 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         }
                         for (J.MethodInvocation setter : builderSetters) {
                             toRemove.add(setter.getId());
+                        }
+
+                        // When a folded setter references an intermediate variable declared after
+                        // the mapper, the builder chain (which replaces the constructor in place)
+                        // would reference that variable before its declaration. Relocate the
+                        // intermediate statements to just before the mapper's containing statement.
+                        // J.NewClass itself implements Statement, so walk up past it to find the
+                        // enclosing declaration or assignment that is the block-level statement.
+                        if (setterUsesIntermediate[0] && !movableStmts.isEmpty()) {
+                            Statement mapperStmt = namedVar != null ?
+                                    getCursor().firstEnclosing(J.VariableDeclarations.class) :
+                                    assignment;
+                            if (mapperStmt != null) {
+                                Set<UUID> movableIds = new HashSet<>();
+                                for (Statement m : movableStmts) {
+                                    movableIds.add(m.getId());
+                                }
+                                doAfterVisit(relocateBeforeMapper(mapperStmt.getId(), movableIds));
+                            }
                         }
 
                         doAfterVisit(inlineWrappedVariable());
@@ -436,8 +457,10 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         if (varIdent != null) {
                             J.Block block = getCursor().firstEnclosing(J.Block.class);
                             if (block != null) {
+                                List<Statement> movableStmts = new ArrayList<>();
+                                boolean[] setterUsesIntermediate = {false};
                                 List<J.MethodInvocation> standaloneSetters = collectStandaloneSetters(
-                                        block, varIdent, new HashSet<>());
+                                        block, varIdent, new HashSet<>(), movableStmts, setterUsesIntermediate);
                                 if (!standaloneSetters.isEmpty()) {
                                     setterCalls.addAll(standaloneSetters);
 
@@ -450,6 +473,19 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                     }
                                     for (J.MethodInvocation setter : standaloneSetters) {
                                         toRemove.add(setter.getId());
+                                    }
+
+                                    if (setterUsesIntermediate[0] && !movableStmts.isEmpty()) {
+                                        J.VariableDeclarations vd = getCursor().firstEnclosing(J.VariableDeclarations.class);
+                                        J.Assignment assignment = getCursor().firstEnclosing(J.Assignment.class);
+                                        Statement mapperStmt = vd != null ? vd : assignment;
+                                        if (mapperStmt != null) {
+                                            Set<UUID> movableIds = new HashSet<>();
+                                            for (Statement m : movableStmts) {
+                                                movableIds.add(m.getId());
+                                            }
+                                            doAfterVisit(relocateBeforeMapper(mapperStmt.getId(), movableIds));
+                                        }
                                     }
 
                                     doAfterVisit(inlineWrappedVariable());
@@ -483,9 +519,17 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                      * declaration/assignment. Stops collecting when the variable is referenced in a
                      * non-setter context (e.g., passed to another method). Both known and unknown
                      * setters are collected; unknown setters will get TODO comments in the builder chain.
+                     * <p>
+                     * Statements between the mapper declaration and the last collected setter that
+                     * do not reference the mapper are added to {@code movableStmtsOut}. If any
+                     * collected setter references a variable declared in one of those statements,
+                     * {@code setterUsesIntermediateOut[0]} is set to {@code true}; the caller must
+                     * relocate the movable statements to appear before the mapper's declaration so
+                     * the builder chain (which replaces the constructor in place) can resolve them.
                      */
                     private List<J.MethodInvocation> collectStandaloneSetters(
-                            J.Block block, J.Identifier varIdent, Set<J.Identifier> intermediateVars) {
+                            J.Block block, J.Identifier varIdent, Set<J.Identifier> intermediateVars,
+                            List<Statement> movableStmtsOut, boolean[] setterUsesIntermediateOut) {
                         List<J.MethodInvocation> setters = new ArrayList<>();
                         boolean pastDeclaration = false;
                         boolean collecting = true;
@@ -514,32 +558,30 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                 continue;
                             }
 
-                            // Track intermediate variable declarations
-                            J.VariableDeclarations vd = extractVariableDeclarations(stmt);
-                            if (vd != null) {
-                                for (J.VariableDeclarations.NamedVariable v : vd.getVariables()) {
-                                    intermediateVars.add(v.getName());
-                                }
-                            }
-
                             // Look inside init blocks for setter calls (must be checked BEFORE
                             // extractMethodInvocation, which would visit into the block and find
                             // only the first MI)
                             if (stmt instanceof J.Block) {
+                                // Track intermediate variable declarations from the outer scope
+                                J.VariableDeclarations outerVd = extractVariableDeclarations(stmt);
+                                if (outerVd != null) {
+                                    for (J.VariableDeclarations.NamedVariable v : outerVd.getVariables()) {
+                                        intermediateVars.add(v.getName());
+                                    }
+                                }
                                 for (Statement innerStmt : ((J.Block) stmt).getStatements()) {
                                     if (!collecting) {
                                         break;
                                     }
                                     J.MethodInvocation initMi = extractMethodInvocation(innerStmt);
                                     if (initMi != null && isCallOnVariable(initMi, varIdent)) {
-                                        if (argumentReferencesAny(initMi, intermediateVars)) {
-                                            collecting = false;
-                                            continue;
-                                        }
                                         if (SetterToBuilderMapping.fromSetter(initMi.getName().getSimpleName()) == null &&
                                                 !isSetterReturnType(initMi)) {
                                             collecting = false;
                                             continue;
+                                        }
+                                        if (argumentReferencesAny(initMi, intermediateVars)) {
+                                            setterUsesIntermediateOut[0] = true;
                                         }
                                         setters.add(initMi);
                                         continue;
@@ -554,21 +596,33 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             // Check if statement is a setter call on the variable
                             J.MethodInvocation mi = extractMethodInvocation(stmt);
                             if (mi != null && isCallOnVariable(mi, varIdent)) {
-                                if (argumentReferencesAny(mi, intermediateVars)) {
-                                    collecting = false;
-                                    continue;
-                                }
                                 if (SetterToBuilderMapping.fromSetter(mi.getName().getSimpleName()) == null &&
                                         !isSetterReturnType(mi)) {
                                     collecting = false;
                                     continue;
                                 }
+                                if (argumentReferencesAny(mi, intermediateVars)) {
+                                    setterUsesIntermediateOut[0] = true;
+                                }
                                 setters.add(mi);
                                 continue;
                             }
 
+                            // Non-setter statement: if it references the mapper we must stop, since
+                            // its meaning depends on the mapper's constructed state (which we're
+                            // about to fold into a builder chain). Otherwise it's a safe intermediate
+                            // statement that can be relocated before the mapper if needed.
                             if (referencesVariable(stmt, varIdent)) {
                                 collecting = false;
+                                continue;
+                            }
+
+                            movableStmtsOut.add(stmt);
+                            J.VariableDeclarations vd = extractVariableDeclarations(stmt);
+                            if (vd != null) {
+                                for (J.VariableDeclarations.NamedVariable v : vd.getVariables()) {
+                                    intermediateVars.add(v.getName());
+                                }
                             }
                         }
 
@@ -1207,6 +1261,60 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                     }));
                 }
                 return b;
+            }
+        };
+    }
+
+    /**
+     * Move the statements identified by {@code movableIds} (which appear between the
+     * mapper's containing statement and the last folded setter) to immediately before
+     * the mapper's containing statement, so that the builder chain — which has already
+     * absorbed those variables' references — resolves them lexically.
+     */
+    private static JavaIsoVisitor<ExecutionContext> relocateBeforeMapper(
+            UUID mapperStmtId, Set<UUID> movableIds) {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
+                J.Block b = super.visitBlock(block, ctx);
+                List<Statement> stmts = b.getStatements();
+
+                int mapperIdx = -1;
+                for (int i = 0; i < stmts.size(); i++) {
+                    if (mapperStmtId.equals(stmts.get(i).getId())) {
+                        mapperIdx = i;
+                        break;
+                    }
+                }
+                if (mapperIdx < 0) {
+                    return b;
+                }
+
+                List<Integer> movableIdxs = new ArrayList<>();
+                for (int i = mapperIdx + 1; i < stmts.size(); i++) {
+                    if (movableIds.contains(stmts.get(i).getId())) {
+                        movableIdxs.add(i);
+                    }
+                }
+                if (movableIdxs.isEmpty()) {
+                    return b;
+                }
+
+                List<Statement> newStmts = new ArrayList<>(stmts.size());
+                for (int i = 0; i < mapperIdx; i++) {
+                    newStmts.add(stmts.get(i));
+                }
+                for (int idx : movableIdxs) {
+                    newStmts.add(stmts.get(idx));
+                }
+                newStmts.add(stmts.get(mapperIdx));
+                Set<Integer> moved = new HashSet<>(movableIdxs);
+                for (int i = mapperIdx + 1; i < stmts.size(); i++) {
+                    if (!moved.contains(i)) {
+                        newStmts.add(stmts.get(i));
+                    }
+                }
+                return b.withStatements(newStmts);
             }
         };
     }

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -240,12 +240,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             toRemove.add(setter.getId());
                         }
 
-                        // When a folded setter references an intermediate variable declared after
-                        // the mapper, the builder chain (which replaces the constructor in place)
-                        // would reference that variable before its declaration. Relocate the
-                        // intermediate statements to just before the mapper's containing statement.
-                        // J.NewClass itself implements Statement, so walk up past it to find the
-                        // enclosing declaration or assignment that is the block-level statement.
+                        // J.NewClass implements Statement, so walk up past it to the block-level stmt.
                         if (setterUsesIntermediate[0] && !movableStmts.isEmpty()) {
                             Statement mapperStmt = namedVar != null ?
                                     getCursor().firstEnclosing(J.VariableDeclarations.class) :
@@ -520,12 +515,10 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                      * non-setter context (e.g., passed to another method). Both known and unknown
                      * setters are collected; unknown setters will get TODO comments in the builder chain.
                      * <p>
-                     * Statements between the mapper declaration and the last collected setter that
-                     * do not reference the mapper are added to {@code movableStmtsOut}. If any
-                     * collected setter references a variable declared in one of those statements,
-                     * {@code setterUsesIntermediateOut[0]} is set to {@code true}; the caller must
-                     * relocate the movable statements to appear before the mapper's declaration so
-                     * the builder chain (which replaces the constructor in place) can resolve them.
+                     * Safe statements between the mapper and the last setter are added to
+                     * {@code movableStmtsOut}; {@code setterUsesIntermediateOut[0]} is set when a
+                     * collected setter references a variable declared in one of them — the caller
+                     * must relocate them before the mapper to keep the folded builder well-formed.
                      */
                     private List<J.MethodInvocation> collectStandaloneSetters(
                             J.Block block, J.Identifier varIdent, Set<J.Identifier> intermediateVars,
@@ -562,7 +555,6 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             // extractMethodInvocation, which would visit into the block and find
                             // only the first MI)
                             if (stmt instanceof J.Block) {
-                                // Track intermediate variable declarations from the outer scope
                                 J.VariableDeclarations outerVd = extractVariableDeclarations(stmt);
                                 if (outerVd != null) {
                                     for (J.VariableDeclarations.NamedVariable v : outerVd.getVariables()) {
@@ -608,10 +600,6 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                 continue;
                             }
 
-                            // Non-setter statement: if it references the mapper we must stop, since
-                            // its meaning depends on the mapper's constructed state (which we're
-                            // about to fold into a builder chain). Otherwise it's a safe intermediate
-                            // statement that can be relocated before the mapper if needed.
                             if (referencesVariable(stmt, varIdent)) {
                                 collecting = false;
                                 continue;
@@ -1266,10 +1254,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
     }
 
     /**
-     * Move the statements identified by {@code movableIds} (which appear between the
-     * mapper's containing statement and the last folded setter) to immediately before
-     * the mapper's containing statement, so that the builder chain — which has already
-     * absorbed those variables' references — resolves them lexically.
+     * Move statements identified by {@code movableIds} to just before the mapper's
+     * containing statement, so a folded builder chain resolves them lexically.
      */
     private static JavaIsoVisitor<ExecutionContext> relocateBeforeMapper(
             UUID mapperStmtId, Set<UUID> movableIds) {

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -246,11 +246,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                     getCursor().firstEnclosing(J.VariableDeclarations.class) :
                                     assignment;
                             if (mapperStmt != null) {
-                                Set<UUID> movableIds = new HashSet<>();
-                                for (Statement m : movableStmts) {
-                                    movableIds.add(m.getId());
-                                }
-                                doAfterVisit(relocateBeforeMapper(mapperStmt.getId(), movableIds));
+                                doAfterVisit(relocateBeforeMapper(mapperStmt, movableStmts));
                             }
                         }
 
@@ -475,11 +471,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                         J.Assignment assignment = getCursor().firstEnclosing(J.Assignment.class);
                                         Statement mapperStmt = vd != null ? vd : assignment;
                                         if (mapperStmt != null) {
-                                            Set<UUID> movableIds = new HashSet<>();
-                                            for (Statement m : movableStmts) {
-                                                movableIds.add(m.getId());
-                                            }
-                                            doAfterVisit(relocateBeforeMapper(mapperStmt.getId(), movableIds));
+                                            doAfterVisit(relocateBeforeMapper(mapperStmt, movableStmts));
                                         }
                                     }
 
@@ -1258,7 +1250,14 @@ public class MigrateMapperSettersToBuilder extends Recipe {
      * containing statement, so a folded builder chain resolves them lexically.
      */
     private static JavaIsoVisitor<ExecutionContext> relocateBeforeMapper(
-            UUID mapperStmtId, Set<UUID> movableIds) {
+            Statement mapperStmt, List<Statement> movableStmts) {
+        // Match by ID: doAfterVisit runs later, after the block has been rebuilt, so the
+        // Statement instances collected earlier are no longer reference-equal to the ones here.
+        UUID mapperStmtId = mapperStmt.getId();
+        Set<UUID> movableIds = new HashSet<>();
+        for (Statement m : movableStmts) {
+            movableIds.add(m.getId());
+        }
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.Block visitBlock(J.Block block, ExecutionContext ctx) {

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -670,11 +670,10 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
 
                   class A {
                       JsonMapper create() {
-                          JsonMapper mapper = new JsonMapper();
                           SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-                          // TODO setDateFormat could not be folded to the builder of JsonMapper. Use mapper.rebuild().defaultDateFormat(...).build() or move to the mapper's instantiation site.
-                          mapper.setDateFormat(dateFormat);
-                          return mapper;
+                          return JsonMapper.builder()
+                                  .defaultDateFormat(dateFormat)
+                                  .build();
                       }
                   }
                   """
@@ -1175,6 +1174,127 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
                                   .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                                   .disable(SerializationFeature.INDENT_OUTPUT)
                                   .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(JsonInclude.Include.NON_NULL).withValueInclusion(JsonInclude.Include.NON_NULL))
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void registerModuleWithLocalModuleDeclaredBetween() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.JsonDeserializer;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.module.SimpleModule;
+
+                  class A {
+                      JsonMapper create(JsonDeserializer<String> deserializer) {
+                          JsonMapper mapper = new JsonMapper();
+                          SimpleModule module = new SimpleModule();
+                          module.addDeserializer(String.class, deserializer);
+                          mapper.registerModule(module);
+                          return mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.JsonDeserializer;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.module.SimpleModule;
+
+                  class A {
+                      JsonMapper create(JsonDeserializer<String> deserializer) {
+                          SimpleModule module = new SimpleModule();
+                          module.addDeserializer(String.class, deserializer);
+                          return JsonMapper.builder()
+                                  .addModule(module)
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void registerModuleWithLocalModuleDeclaredBetweenFluentChain() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.JsonDeserializer;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.module.SimpleModule;
+
+                  class A {
+                      JsonMapper create(JsonDeserializer<String> deserializer) {
+                          JsonMapper mapper = new JsonMapper()
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                          SimpleModule module = new SimpleModule();
+                          module.addDeserializer(String.class, deserializer);
+                          mapper.registerModule(module);
+                          return mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.JsonDeserializer;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.module.SimpleModule;
+
+                  class A {
+                      JsonMapper create(JsonDeserializer<String> deserializer) {
+                          SimpleModule module = new SimpleModule();
+                          module.addDeserializer(String.class, deserializer);
+                          return JsonMapper.builder()
+                                  .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                  .addModule(module)
+                                  .build();
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void registerModuleWithLocalModuleDeclaredBetweenAssignedToField() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.JsonDeserializer;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.module.SimpleModule;
+
+                  class A {
+                      JsonMapper objectMapper;
+
+                      void configure(JsonDeserializer<String> deserializer) {
+                          objectMapper = new JsonMapper();
+                          SimpleModule module = new SimpleModule();
+                          module.addDeserializer(String.class, deserializer);
+                          objectMapper.registerModule(module);
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.JsonDeserializer;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+                  import com.fasterxml.jackson.databind.module.SimpleModule;
+
+                  class A {
+                      JsonMapper objectMapper;
+
+                      void configure(JsonDeserializer<String> deserializer) {
+                          SimpleModule module = new SimpleModule();
+                          module.addDeserializer(String.class, deserializer);
+                          objectMapper = JsonMapper.builder()
+                                  .addModule(module)
                                   .build();
                       }
                   }


### PR DESCRIPTION
## Summary

`MigrateMapperSettersToBuilder` previously bailed as soon as a setter's argument referenced a variable declared between the mapper's constructor and the setter — leaving a TODO comment behind. The recipe now folds these into the builder chain and relocates the intermediate declarations to just before the mapper so the resulting code is well-formed.

### Before

```java
JsonMapper mapper = new JsonMapper();
SimpleModule module = new SimpleModule();
module.addDeserializer(String.class, deserializer);
mapper.registerModule(module);
return mapper;
```

Was left with a TODO because `registerModule(module)` referenced `module`, which was declared after the mapper.

### After

```java
SimpleModule module = new SimpleModule();
module.addDeserializer(String.class, deserializer);
return JsonMapper.builder()
        .addModule(module)
        .build();
```

## How

- `collectStandaloneSetters` no longer stops when a setter references a variable declared after the mapper. It records those intermediate statements (as long as they don't themselves reference the mapper) and flags when any folded setter depends on one of them.
- When the flag is set, a `doAfterVisit` post-processor moves the recorded statements to just before the mapper's containing declaration/assignment, so the folded builder chain resolves them lexically.
- Applies to both the bare-constructor path (`visitNewClass`) and the fluent-chain path (`tryMigrateFluentChain`).

An existing test that documented the old fall-back behavior for `setDateFormat` with a `SimpleDateFormat` intermediate variable is updated to reflect the new successful migration.

## Test plan
- [x] `./gradlew test` — all tests pass, including three new cases covering the local-declaration, fluent-chain, and field-assignment shapes.