### PR TITLE
Fold rebuild reassignments into initializers and reclaim final locals

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -306,10 +306,6 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             }
                         }
 
-                        // Reclaim a `final` local: if we can safely strip the `final` modifier
-                        // (the local isn't captured by any lambda or anonymous-class body), take
-                        // the rebuild-assignment path and register the declaration for the
-                        // fold/un-finalize post-passes.
                         if (isTopLevelStatement(getCursor())) {
                             UUID declToUnfinalize = reclaimableFinalLocalDeclarationId(select, getCursor());
                             if (declToUnfinalize != null) {
@@ -804,11 +800,6 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         return vd != null && !vd.hasModifier(J.Modifier.Type.Final);
     }
 
-    /**
-     * Locate the {@link J.VariableDeclarations} declaring {@code ident} as a block-scoped local.
-     * Returns null when the identifier is a method parameter, a field, or otherwise not resolvable
-     * to a local declaration in an enclosing block.
-     */
     private static J.@Nullable VariableDeclarations findLocalDeclaration(J.Identifier ident, Cursor cursor) {
         String name = ident.getSimpleName();
         Cursor c = cursor;
@@ -845,15 +836,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         return null;
     }
 
-    /**
-     * If {@code select} is a {@code final} local that can safely be un-finalized — i.e. it isn't
-     * referenced inside any lambda or anonymous-class body within the enclosing method — return
-     * the id of its {@link J.VariableDeclarations}. Returns null otherwise.
-     * <p>
-     * Un-finalizing a captured local is unsafe because a subsequent reassignment (which the
-     * rebuild rewrite performs) would break the effective-final requirement Java imposes on
-     * captures.
-     */
+    // Captured locals are skipped: reassigning them would break Java's effective-final requirement.
     private static @Nullable UUID reclaimableFinalLocalDeclarationId(Expression select, Cursor cursor) {
         if (!(select instanceof J.Identifier)) {
             return null;
@@ -900,13 +883,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         }.reduce(scope, new HashSet<Boolean>()).isEmpty();
     }
 
-    /**
-     * Strip {@code final} from the declarations in {@code declIds} whose initializer isn't
-     * already a rebuild chain. When the {@code foldRebuildIntoInitializer} pass consumed the
-     * subsequent reassignment, the initializer will contain the rebuild chain and the
-     * declaration keeps {@code final}; otherwise a reassignment still lives further down the
-     * block and {@code final} must be removed.
-     */
+    // If fold already consumed the reassignment (initializer contains a rebuild chain), `final` stays.
     private static JavaIsoVisitor<ExecutionContext> unfinalizeDeclarations(Set<UUID> declIds) {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
@@ -959,15 +936,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         return false;
     }
 
-    /**
-     * Fold a {@code T mapper = <init>;} declaration and an immediately-following
-     * {@code mapper = mapper.rebuild()...build();} reassignment into a single
-     * {@code T mapper = <init>.rebuild()...build();} declaration.
-     * <p>
-     * Only applies when the reassignment is the very next statement, so any intervening read
-     * of {@code mapper} (as in the {@code trailingSetterAfterGapOnLocal} shape) prevents the
-     * fold and preserves observable semantics.
-     */
+    // Only fold when the reassignment is the immediately-following statement, so intervening reads
+    // can't observe a different value after folding.
     private static JavaIsoVisitor<ExecutionContext> foldRebuildIntoInitializer() {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
@@ -1007,20 +977,15 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                 !TypeUtils.isOfType(nv.getName().getType(), lhs.getType())) {
             return null;
         }
-        // The `initializer`'s own prefix carries the whitespace between `=` and the expression.
-        // The reassignment's outermost MI carries a duplicate leading prefix (`= mapper.rebuild()...`),
-        // so drop it to avoid stacking whitespace at the `=`.
+        // Drop the reassignment's outer prefix; the initializer's own prefix owns the `=` gap.
         Expression newSelect = reb.rebuildCall.withSelect(initializer);
         for (J.MethodInvocation chainCall : reb.chainCalls) {
             newSelect = chainCall.withSelect(newSelect);
         }
         J.MethodInvocation newBuild = reb.buildCall.withSelect(newSelect).withPrefix(Space.EMPTY);
-        J.VariableDeclarations newVd = vd.withVariables(singletonList(nv.withInitializer(newBuild)));
-        // Preserve the declaration's original statement position (prefix, etc.).
         if (declStmt instanceof J.VariableDeclarations) {
-            return newVd;
+            return vd.withVariables(singletonList(nv.withInitializer(newBuild)));
         }
-        // For K.Property or other wrappers we don't attempt the fold.
         return null;
     }
 

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -174,6 +174,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         // https://github.com/openrewrite/rewrite/issues/7434
         preconditions.add(new UsesType<>("com.fasterxml.jackson.databind.ObjectMapper", false));
         preconditions.add(new UsesMethod<>(KOTLIN_EXTENSIONS_FQN + " " + JACKSON_OBJECT_MAPPER_NAME + "()", false));
+        Set<UUID> reclaimableFinalDecls = new HashSet<>();
         return Preconditions.check(
                 Preconditions.or(preconditions.toArray(new TreeVisitor[0])),
                 new JavaVisitor<ExecutionContext>() {
@@ -185,6 +186,10 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             doAfterVisit(new UpdateSerializationInclusionConfiguration().getVisitor());
                             doAfterVisit(new UpdateAutoDetectVisibilityConfiguration().getVisitor());
                             doAfterVisit(coalesceRebuildAssignments());
+                            doAfterVisit(foldRebuildIntoInitializer());
+                            if (!reclaimableFinalDecls.isEmpty()) {
+                                doAfterVisit(unfinalizeDeclarations(reclaimableFinalDecls));
+                            }
                         }
                         return visited;
                     }
@@ -302,14 +307,15 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         }
 
                         // Reclaim a `final` local: if we can safely strip the `final` modifier
-                        // (the local isn't captured by any lambda or anonymous-class body), do so
-                        // and take the rebuild-assignment path rather than leaving a TODO.
+                        // (the local isn't captured by any lambda or anonymous-class body), take
+                        // the rebuild-assignment path and register the declaration for the
+                        // fold/un-finalize post-passes.
                         if (isTopLevelStatement(getCursor())) {
                             UUID declToUnfinalize = reclaimableFinalLocalDeclarationId(select, getCursor());
                             if (declToUnfinalize != null) {
                                 J rebuilt = rewriteAsRebuildAssignment(mi, select, matchedMapper, mapping, ctx);
                                 if (rebuilt != null) {
-                                    doAfterVisit(unfinalizeDeclaration(declToUnfinalize));
+                                    reclaimableFinalDecls.add(declToUnfinalize);
                                     return rebuilt;
                                 }
                             }
@@ -902,12 +908,22 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         return captured[0];
     }
 
-    private static JavaIsoVisitor<ExecutionContext> unfinalizeDeclaration(UUID declId) {
+    /**
+     * Strip {@code final} from the declarations in {@code declIds} whose initializer isn't
+     * already a rebuild chain. When the {@code foldRebuildIntoInitializer} pass consumed the
+     * subsequent reassignment, the initializer will contain the rebuild chain and the
+     * declaration keeps {@code final}; otherwise a reassignment still lives further down the
+     * block and {@code final} must be removed.
+     */
+    private static JavaIsoVisitor<ExecutionContext> unfinalizeDeclarations(Set<UUID> declIds) {
         return new JavaIsoVisitor<ExecutionContext>() {
             @Override
             public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                 J.VariableDeclarations vd = super.visitVariableDeclarations(multiVariable, ctx);
-                if (!vd.getId().equals(declId)) {
+                if (!declIds.contains(vd.getId())) {
+                    return vd;
+                }
+                if (initializerContainsRebuild(vd)) {
                     return vd;
                 }
                 List<J.Modifier> modifiers = vd.getModifiers();
@@ -935,6 +951,106 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                 return vd.withModifiers(updated);
             }
         };
+    }
+
+    private static boolean initializerContainsRebuild(J.VariableDeclarations vd) {
+        for (J.VariableDeclarations.NamedVariable nv : vd.getVariables()) {
+            Expression init = nv.getInitializer();
+            if (init instanceof J.MethodInvocation && chainContainsRebuild((J.MethodInvocation) init)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean chainContainsRebuild(J.MethodInvocation mi) {
+        Expression current = mi;
+        while (current instanceof J.MethodInvocation) {
+            J.MethodInvocation call = (J.MethodInvocation) current;
+            if ("rebuild".equals(call.getName().getSimpleName())) {
+                return true;
+            }
+            current = call.getSelect();
+        }
+        return false;
+    }
+
+    /**
+     * Fold a {@code T mapper = <init>;} declaration and an immediately-following
+     * {@code mapper = mapper.rebuild()...build();} reassignment into a single
+     * {@code T mapper = <init>.rebuild()...build();} declaration.
+     * <p>
+     * Only applies when the reassignment is the very next statement, so any intervening read
+     * of {@code mapper} (as in the {@code trailingSetterAfterGapOnLocal} shape) prevents the
+     * fold and preserves observable semantics.
+     */
+    private static JavaIsoVisitor<ExecutionContext> foldRebuildIntoInitializer() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
+                J.Block b = super.visitBlock(block, ctx);
+                List<Statement> stmts = b.getStatements();
+                if (stmts.size() < 2) {
+                    return b;
+                }
+                List<Statement> merged = new ArrayList<>(stmts.size());
+                boolean changed = false;
+                int i = 0;
+                while (i < stmts.size()) {
+                    if (i + 1 >= stmts.size()) {
+                        merged.add(stmts.get(i));
+                        i++;
+                        continue;
+                    }
+                    Statement folded = tryFoldPair(stmts.get(i), stmts.get(i + 1));
+                    if (folded == null) {
+                        merged.add(stmts.get(i));
+                        i++;
+                        continue;
+                    }
+                    merged.add(folded);
+                    i += 2;
+                    changed = true;
+                }
+                return changed ? b.withStatements(merged) : b;
+            }
+        };
+    }
+
+    private static @Nullable Statement tryFoldPair(Statement declStmt, Statement reassignStmt) {
+        J.VariableDeclarations vd = extractVariableDeclarations(declStmt);
+        if (vd == null || vd.getVariables().size() != 1) {
+            return null;
+        }
+        J.VariableDeclarations.NamedVariable nv = vd.getVariables().get(0);
+        Expression initializer = nv.getInitializer();
+        if (initializer == null) {
+            return null;
+        }
+        RebuildParts reb = tryParseRebuildAssignment(reassignStmt);
+        if (reb == null || !(reb.lhs instanceof J.Identifier)) {
+            return null;
+        }
+        J.Identifier lhs = (J.Identifier) reb.lhs;
+        if (!nv.getName().getSimpleName().equals(lhs.getSimpleName()) ||
+                !TypeUtils.isOfType(nv.getName().getType(), lhs.getType())) {
+            return null;
+        }
+        // The `initializer`'s own prefix carries the whitespace between `=` and the expression.
+        // The reassignment's outermost MI carries a duplicate leading prefix (`= mapper.rebuild()...`),
+        // so drop it to avoid stacking whitespace at the `=`.
+        Expression newSelect = reb.rebuildCall.withSelect(initializer);
+        for (J.MethodInvocation chainCall : reb.chainCalls) {
+            newSelect = chainCall.withSelect(newSelect);
+        }
+        J.MethodInvocation newBuild = reb.buildCall.withSelect(newSelect).withPrefix(Space.EMPTY);
+        J.VariableDeclarations newVd = vd.withVariables(singletonList(nv.withInitializer(newBuild)));
+        // Preserve the declaration's original statement position (prefix, etc.).
+        if (declStmt instanceof J.VariableDeclarations) {
+            return newVd;
+        }
+        // For K.Property or other wrappers we don't attempt the fold.
+        return null;
     }
 
     private static JavaIsoVisitor<ExecutionContext> coalesceRebuildAssignments() {

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -876,13 +876,9 @@ public class MigrateMapperSettersToBuilder extends Recipe {
     }
 
     private static boolean isReferencedInsideCapture(J.Block scope, J.Identifier target) {
-        boolean[] captured = {false};
-        new JavaIsoVisitor<boolean[]>() {
+        return !new JavaIsoVisitor<Set<Boolean>>() {
             @Override
-            public J.Identifier visitIdentifier(J.Identifier ident, boolean[] flag) {
-                if (flag[0]) {
-                    return ident;
-                }
+            public J.Identifier visitIdentifier(J.Identifier ident, Set<Boolean> set) {
                 if (!target.getSimpleName().equals(ident.getSimpleName())) {
                     return ident;
                 }
@@ -892,20 +888,16 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                 Cursor c = getCursor().getParent();
                 while (c != null && c.getValue() != scope) {
                     Object v = c.getValue();
-                    if (v instanceof J.Lambda) {
-                        flag[0] = true;
-                        return ident;
-                    }
-                    if (v instanceof J.NewClass && ((J.NewClass) v).getBody() != null) {
-                        flag[0] = true;
+                    if (v instanceof J.Lambda ||
+                            (v instanceof J.NewClass && ((J.NewClass) v).getBody() != null)) {
+                        set.add(true);
                         return ident;
                     }
                     c = c.getParent();
                 }
                 return ident;
             }
-        }.visit(scope, captured);
-        return captured[0];
+        }.reduce(scope, new HashSet<Boolean>()).isEmpty();
     }
 
     /**
@@ -927,28 +919,20 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                     return vd;
                 }
                 List<J.Modifier> modifiers = vd.getModifiers();
-                int finalIdx = -1;
-                for (int i = 0; i < modifiers.size(); i++) {
-                    if (modifiers.get(i).getType() == J.Modifier.Type.Final) {
-                        finalIdx = i;
-                        break;
-                    }
+                if (modifiers.isEmpty() || modifiers.get(0).getType() != J.Modifier.Type.Final) {
+                    // `final` is absent or not leading, so removing it can't affect the declaration's
+                    // leading whitespace; just drop it wherever it appears.
+                    return vd.withModifiers(ListUtils.map(modifiers,
+                            m -> m.getType() == J.Modifier.Type.Final ? null : m));
                 }
-                if (finalIdx < 0) {
-                    return vd;
+                // `final` leads the declaration, so carry its prefix to whatever becomes first.
+                Space carry = modifiers.get(0).getPrefix();
+                if (modifiers.size() == 1) {
+                    return vd.getTypeExpression() == null ? vd.withModifiers(emptyList()) :
+                            vd.withModifiers(emptyList()).withTypeExpression(vd.getTypeExpression().withPrefix(carry));
                 }
-                List<J.Modifier> updated = new ArrayList<>(modifiers);
-                J.Modifier removed = updated.remove(finalIdx);
-                if (finalIdx == 0) {
-                    Space carry = removed.getPrefix();
-                    if (!updated.isEmpty()) {
-                        updated.set(0, updated.get(0).withPrefix(carry));
-                    } else if (vd.getTypeExpression() != null) {
-                        return vd.withModifiers(updated)
-                                .withTypeExpression(vd.getTypeExpression().withPrefix(carry));
-                    }
-                }
-                return vd.withModifiers(updated);
+                return vd.withModifiers(ListUtils.mapFirst(modifiers.subList(1, modifiers.size()),
+                        m -> m.withPrefix(carry)));
             }
         };
     }
@@ -990,29 +974,16 @@ public class MigrateMapperSettersToBuilder extends Recipe {
             public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
                 J.Block b = super.visitBlock(block, ctx);
                 List<Statement> stmts = b.getStatements();
-                if (stmts.size() < 2) {
-                    return b;
-                }
-                List<Statement> merged = new ArrayList<>(stmts.size());
-                boolean changed = false;
-                int i = 0;
-                while (i < stmts.size()) {
-                    if (i + 1 >= stmts.size()) {
-                        merged.add(stmts.get(i));
-                        i++;
-                        continue;
+                // A fold consumes a (declaration, reassignment) pair; the reassignment can never
+                // be a declaration, so pairs never overlap. Each statement is therefore the head
+                // of a fold, the tail dropped by the fold at the previous index, or left as-is.
+                return b.withStatements(ListUtils.map(stmts, (i, s) -> {
+                    if (i > 0 && tryFoldPair(stmts.get(i - 1), s) != null) {
+                        return null;
                     }
-                    Statement folded = tryFoldPair(stmts.get(i), stmts.get(i + 1));
-                    if (folded == null) {
-                        merged.add(stmts.get(i));
-                        i++;
-                        continue;
-                    }
-                    merged.add(folded);
-                    i += 2;
-                    changed = true;
-                }
-                return changed ? b.withStatements(merged) : b;
+                    Statement folded = i + 1 < stmts.size() ? tryFoldPair(s, stmts.get(i + 1)) : null;
+                    return folded != null ? folded : s;
+                }));
             }
         };
     }

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -301,6 +301,20 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             }
                         }
 
+                        // Reclaim a `final` local: if we can safely strip the `final` modifier
+                        // (the local isn't captured by any lambda or anonymous-class body), do so
+                        // and take the rebuild-assignment path rather than leaving a TODO.
+                        if (isTopLevelStatement(getCursor())) {
+                            UUID declToUnfinalize = reclaimableFinalLocalDeclarationId(select, getCursor());
+                            if (declToUnfinalize != null) {
+                                J rebuilt = rewriteAsRebuildAssignment(mi, select, matchedMapper, mapping, ctx);
+                                if (rebuilt != null) {
+                                    doAfterVisit(unfinalizeDeclaration(declToUnfinalize));
+                                    return rebuilt;
+                                }
+                            }
+                        }
+
                         // Not eligible for builder migration - add a TODO comment
                         String simpleMapperName = matchedMapper.substring(matchedMapper.lastIndexOf('.') + 1);
                         String commentText = String.format(
@@ -780,6 +794,16 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         if (fieldType != null && fieldType.hasFlags(Flag.Final)) {
             return false;
         }
+        J.VariableDeclarations vd = findLocalDeclaration(ident, cursor);
+        return vd != null && !vd.hasModifier(J.Modifier.Type.Final);
+    }
+
+    /**
+     * Locate the {@link J.VariableDeclarations} declaring {@code ident} as a block-scoped local.
+     * Returns null when the identifier is a method parameter, a field, or otherwise not resolvable
+     * to a local declaration in an enclosing block.
+     */
+    private static J.@Nullable VariableDeclarations findLocalDeclaration(J.Identifier ident, Cursor cursor) {
         String name = ident.getSimpleName();
         Cursor c = cursor;
         while (c != null) {
@@ -793,7 +817,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                     for (J.VariableDeclarations.NamedVariable nv : vd.getVariables()) {
                         if (name.equals(nv.getName().getSimpleName()) &&
                                 TypeUtils.isOfType(nv.getName().getType(), ident.getType())) {
-                            return !vd.hasModifier(J.Modifier.Type.Final);
+                            return vd;
                         }
                     }
                 }
@@ -803,16 +827,114 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                     if (p instanceof J.VariableDeclarations) {
                         for (J.VariableDeclarations.NamedVariable nv : ((J.VariableDeclarations) p).getVariables()) {
                             if (name.equals(nv.getName().getSimpleName())) {
-                                return false;
+                                return null;
                             }
                         }
                     }
                 }
-                return false;
+                return null;
             }
             c = c.getParent();
         }
-        return false;
+        return null;
+    }
+
+    /**
+     * If {@code select} is a {@code final} local that can safely be un-finalized — i.e. it isn't
+     * referenced inside any lambda or anonymous-class body within the enclosing method — return
+     * the id of its {@link J.VariableDeclarations}. Returns null otherwise.
+     * <p>
+     * Un-finalizing a captured local is unsafe because a subsequent reassignment (which the
+     * rebuild rewrite performs) would break the effective-final requirement Java imposes on
+     * captures.
+     */
+    private static @Nullable UUID reclaimableFinalLocalDeclarationId(Expression select, Cursor cursor) {
+        if (!(select instanceof J.Identifier)) {
+            return null;
+        }
+        J.Identifier ident = (J.Identifier) select;
+        J.VariableDeclarations vd = findLocalDeclaration(ident, cursor);
+        if (vd == null || !vd.hasModifier(J.Modifier.Type.Final)) {
+            return null;
+        }
+        J.MethodDeclaration enclosingMethod = cursor.firstEnclosing(J.MethodDeclaration.class);
+        J.Block scope = enclosingMethod != null ? enclosingMethod.getBody() :
+                cursor.firstEnclosing(J.Block.class);
+        if (scope == null) {
+            return null;
+        }
+        if (isReferencedInsideCapture(scope, ident)) {
+            return null;
+        }
+        return vd.getId();
+    }
+
+    private static boolean isReferencedInsideCapture(J.Block scope, J.Identifier target) {
+        boolean[] captured = {false};
+        new JavaIsoVisitor<boolean[]>() {
+            @Override
+            public J.Identifier visitIdentifier(J.Identifier ident, boolean[] flag) {
+                if (flag[0]) {
+                    return ident;
+                }
+                if (!target.getSimpleName().equals(ident.getSimpleName())) {
+                    return ident;
+                }
+                if (target.getType() != null && !TypeUtils.isOfType(ident.getType(), target.getType())) {
+                    return ident;
+                }
+                Cursor c = getCursor().getParent();
+                while (c != null && c.getValue() != scope) {
+                    Object v = c.getValue();
+                    if (v instanceof J.Lambda) {
+                        flag[0] = true;
+                        return ident;
+                    }
+                    if (v instanceof J.NewClass && ((J.NewClass) v).getBody() != null) {
+                        flag[0] = true;
+                        return ident;
+                    }
+                    c = c.getParent();
+                }
+                return ident;
+            }
+        }.visit(scope, captured);
+        return captured[0];
+    }
+
+    private static JavaIsoVisitor<ExecutionContext> unfinalizeDeclaration(UUID declId) {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                J.VariableDeclarations vd = super.visitVariableDeclarations(multiVariable, ctx);
+                if (!vd.getId().equals(declId)) {
+                    return vd;
+                }
+                List<J.Modifier> modifiers = vd.getModifiers();
+                int finalIdx = -1;
+                for (int i = 0; i < modifiers.size(); i++) {
+                    if (modifiers.get(i).getType() == J.Modifier.Type.Final) {
+                        finalIdx = i;
+                        break;
+                    }
+                }
+                if (finalIdx < 0) {
+                    return vd;
+                }
+                List<J.Modifier> updated = new ArrayList<>(modifiers);
+                J.Modifier removed = updated.remove(finalIdx);
+                if (finalIdx == 0) {
+                    Space carry = removed.getPrefix();
+                    if (!updated.isEmpty()) {
+                        updated.set(0, updated.get(0).withPrefix(carry));
+                    } else if (vd.getTypeExpression() != null) {
+                        return vd.withModifiers(updated)
+                                .withTypeExpression(vd.getTypeExpression().withPrefix(carry));
+                    }
+                }
+                return vd.withModifiers(updated);
+            }
+        };
     }
 
     private static JavaIsoVisitor<ExecutionContext> coalesceRebuildAssignments() {

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -846,6 +846,170 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
         }
 
         @Test
+        void finalLocalIsUnfinalizedAndRewritten() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          final JsonMapper mapper = new JsonMapper();
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          System.out.println(mapper);
+                          mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                          return mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper create() {
+                          JsonMapper mapper = JsonMapper.builder()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .build();
+                          System.out.println(mapper);
+                          mapper = mapper.rebuild()
+                                  .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                                  .build();
+                          return mapper;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void finalLocalFromMethodCallCoalescesRebuildChain() {
+            // Regression coverage for https://github.com/openrewrite/rewrite-jackson/issues/155
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      private static JsonMapper initObjectMapper() {
+                          return new JsonMapper();
+                      }
+
+                      private static JsonMapper initObjectMapperWithIso8601Dates() {
+                          final JsonMapper mapper = initObjectMapper();
+                          mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                          mapper.disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
+                          return mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      private static JsonMapper initObjectMapper() {
+                          return new JsonMapper();
+                      }
+
+                      private static JsonMapper initObjectMapperWithIso8601Dates() {
+                          JsonMapper mapper = initObjectMapper();
+                          mapper = mapper.rebuild()
+                                  .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                                  .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                  .build();
+                          return mapper;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void finalLocalCapturedByLambdaKeepsTodoComment() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  import java.util.function.Supplier;
+
+                  class A {
+                      Supplier<JsonMapper> create() {
+                          final JsonMapper mapper = new JsonMapper();
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          return () -> mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  import java.util.function.Supplier;
+
+                  class A {
+                      Supplier<JsonMapper> create() {
+                          final JsonMapper mapper = JsonMapper.builder()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .build();
+                          return () -> mapper;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void finalLocalCapturedByAnonymousClassKeepsTodoComment() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      Runnable create() {
+                          final JsonMapper mapper = new JsonMapper();
+                          System.out.println(mapper);
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          return new Runnable() {
+                              @Override public void run() {
+                                  System.out.println(mapper);
+                              }
+                          };
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      Runnable create() {
+                          final JsonMapper mapper = new JsonMapper();
+                          System.out.println(mapper);
+                          // TODO disable could not be folded to the builder of JsonMapper. Use mapper.rebuild().disable(...).build() or move to the mapper's instantiation site.
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          return new Runnable() {
+                              @Override public void run() {
+                                  System.out.println(mapper);
+                              }
+                          };
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void finalFieldStillGetsTodoComment() {
             rewriteRun(
               java(

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -916,10 +916,50 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
                       }
 
                       private static JsonMapper initObjectMapperWithIso8601Dates() {
-                          JsonMapper mapper = initObjectMapper();
-                          mapper = mapper.rebuild()
+                          final JsonMapper mapper = initObjectMapper().rebuild()
                                   .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                                   .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                                  .build();
+                          return mapper;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void nonFinalLocalFromMethodCallFoldsIntoInitializer() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      private static JsonMapper initObjectMapper() {
+                          return new JsonMapper();
+                      }
+
+                      private static JsonMapper build() {
+                          JsonMapper mapper = initObjectMapper();
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          return mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      private static JsonMapper initObjectMapper() {
+                          return new JsonMapper();
+                      }
+
+                      private static JsonMapper build() {
+                          JsonMapper mapper = initObjectMapper().rebuild()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
                                   .build();
                           return mapper;
                       }


### PR DESCRIPTION
Fixes https://github.com/openrewrite/rewrite-jackson/issues/155.

Two related improvements to `MigrateMapperSettersToBuilder` for mappers configured in a helper method away from their construction site.

## 1. Fold `mapper = mapper.rebuild()...build();` into the initializer when adjacent

When a rebuild reassignment is the statement immediately following the declaration, fold the two into a single-statement form. The issue #155 shape:

```java
final ObjectMapper mapper = initObjectMapper();
mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
mapper.disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
return mapper;
```

now migrates to:

```java
final JsonMapper mapper = initObjectMapper().rebuild()
        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
        .disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
        .build();
return mapper;
```

The fold intentionally requires the reassignment to be the very next statement — any intervening read of the local (as in the existing `trailingSetterAfterGapOnLocal` shape, where `System.out.println(mapper)` sits between the setters) prevents the fold and preserves observable semantics.

## 2. Reclaim `final` locals so the rebuild rewrite applies

Before this PR, `final` locals were unconditionally skipped by the rebuild-assignment path added in #153 — the receiver has to be reassignable — so #155's exact shape (`final ObjectMapper mapper = ...;` followed by two configuration calls) got the TODO fallback and shipped broken code once the `SerializationFeature` → `DateTimeFeature` rename ran. Now:

- If the fold above succeeds, the declaration is initialized once and `final` is preserved.
- If the fold can't apply (an intervening read forces the two-statement form), the recipe strips the `final` modifier so the rebuild reassignment is legal.
- Un-finalizing is skipped when the local is referenced inside any lambda or anonymous-class body in its scope, because a subsequent reassignment would break Java's effective-final capture requirement. Those cases keep the existing TODO.

## How

- `foldRebuildIntoInitializer` post-pass: walks each block, and when it sees `T name = <init>;` immediately followed by `name = name.rebuild()....build();`, merges them into `T name = <init>.rebuild()....build();`. Uses the existing `RebuildParts` / `tryParseRebuildAssignment` helpers to reconstruct the chain rooted at the initializer.
- `foldRebuildIntoInitializer` runs after `coalesceRebuildAssignments` (so consecutive rebuild reassignments become one chain before folding) and before `unfinalizeDeclarations`. All three post-passes are now scheduled from `visitBlock` so ordering is explicit; `visitMethodInvocation` records reclaim candidates in a per-visitor `Set<UUID>` instead of scheduling `doAfterVisit` directly.
- `unfinalizeDeclarations` inspects each candidate declaration and only strips `final` when the initializer doesn't already contain a `.rebuild()` chain — i.e. only when the fold couldn't consume the reassignment.
- `findLocalDeclaration` is factored out of `isReassignableLocal` and reused by `reclaimableFinalLocalDeclarationId`. `isReferencedInsideCapture` walks the enclosing method body for lambda/anonymous-class capture; those decls stay `final` and get the TODO.
- Final fields intentionally still get the TODO — this change is scoped to locals.

## Test plan

- [x] `./gradlew test` — full suite passes, including five new cases under `RewriteAsRebuild`:
  - `finalLocalIsUnfinalizedAndRewritten` — final local with an intervening read: two-statement form, `final` stripped.
  - `finalLocalFromMethodCallCoalescesRebuildChain` — the issue #155 reproducer: coalesce + fold + `final` preserved.
  - `nonFinalLocalFromMethodCallFoldsIntoInitializer` — proves the fold applies to non-final locals too.
  - `finalLocalCapturedByLambdaKeepsTodoComment` — capture guard for `Supplier<JsonMapper>` lambdas.
  - `finalLocalCapturedByAnonymousClassKeepsTodoComment` — capture guard for anonymous inner classes.
- [x] Existing `trailingSetterAfterGapOnLocal` still asserts the two-statement form (intervening read prevents fold).
- [x] Existing `finalFieldStillGetsTodoComment` unchanged: final fields intentionally excluded.