### PR TITLE
Fold mapper setters only for the variable the mapper directly initializes

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -208,17 +208,15 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             return nc;
                         }
 
-                        // Determine variable identifier from local declaration or field assignment
-                        J.Identifier varIdent;
-                        J.VariableDeclarations.NamedVariable namedVar = getCursor().firstEnclosing(J.VariableDeclarations.NamedVariable.class);
-                        J.Assignment assignment = getCursor().firstEnclosing(J.Assignment.class);
-                        if (namedVar != null) {
-                            varIdent = namedVar.getName();
-                        } else if (assignment != null && assignment.getVariable() instanceof J.Identifier) {
-                            varIdent = (J.Identifier) assignment.getVariable();
-                        } else {
+                        // Determine the owning variable, but only when this constructor call is the
+                        // variable's direct initializer / assigned value. A mapper nested inside
+                        // another expression (e.g. an argument to another constructor) does not make
+                        // the enclosing variable a mapper, so setters on it must not be folded.
+                        Cursor owner = enclosingOwnerCursor(getCursor());
+                        if (owner == null) {
                             return nc;
                         }
+                        J.Identifier varIdent = ownerVariable(owner);
 
                         J.Block block = getCursor().firstEnclosing(J.Block.class);
                         if (block == null) {
@@ -248,9 +246,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
 
                         // J.NewClass implements Statement, so walk up past it to the block-level stmt.
                         if (setterUsesIntermediate[0] && !movableStmts.isEmpty()) {
-                            Statement mapperStmt = namedVar != null ?
-                                    getCursor().firstEnclosing(J.VariableDeclarations.class) :
-                                    assignment;
+                            Statement mapperStmt = ownerStatement(owner);
                             if (mapperStmt != null) {
                                 doAfterVisit(relocateBeforeMapper(mapperStmt, movableStmts));
                             }
@@ -328,8 +324,14 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             return mi;
                         }
 
-                        String prefixWhitespace = mi.getPrefix().getWhitespace();
-                        TextComment comment = new TextComment(false, commentText, prefixWhitespace, Markers.EMPTY);
+                        String suffix = mi.getPrefix().getWhitespace();
+                        if (!suffix.contains("\n")) {
+                            // The invocation is embedded in a larger statement (e.g. an initializer);
+                            // without a line break of its own, the line comment would swallow the
+                            // rest of the line. Break at the enclosing statement's indent instead.
+                            suffix = enclosingBlockStatementWhitespace(getCursor());
+                        }
+                        TextComment comment = new TextComment(false, commentText, suffix, Markers.EMPTY);
                         return mi.withPrefix(mi.getPrefix().withComments(
                                 ListUtils.concat(mi.getPrefix().getComments(), comment)));
                     }
@@ -373,7 +375,9 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         }
                         JavaType returnType = methodType.getReturnType();
                         if (returnType == JavaType.Primitive.Void) {
-                            return true;
+                            // A void operational method (e.g. writeValue) must not be treated
+                            // as an unknown setter and folded into the builder.
+                            return mi.getName().getSimpleName().startsWith("set");
                         }
                         return TypeUtils.isAssignableTo("com.fasterxml.jackson.databind.ObjectMapper", returnType);
                     }
@@ -469,10 +473,11 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             return null;
                         }
 
-                        // When the fluent chain is assigned to a variable, also collect
+                        // When the fluent chain is directly assigned to a variable, also collect
                         // standalone setter calls that follow the assignment statement
-                        J.Identifier varIdent = findVariableIdentifier();
-                        if (varIdent != null) {
+                        Cursor owner = enclosingOwnerCursor(getCursor());
+                        if (owner != null) {
+                            J.Identifier varIdent = ownerVariable(owner);
                             J.Block block = getCursor().firstEnclosing(J.Block.class);
                             if (block != null) {
                                 List<Statement> movableStmts = new ArrayList<>();
@@ -494,9 +499,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                     }
 
                                     if (setterUsesIntermediate[0] && !movableStmts.isEmpty()) {
-                                        J.VariableDeclarations vd = getCursor().firstEnclosing(J.VariableDeclarations.class);
-                                        J.Assignment assignment = getCursor().firstEnclosing(J.Assignment.class);
-                                        Statement mapperStmt = vd != null ? vd : assignment;
+                                        Statement mapperStmt = ownerStatement(owner);
                                         if (mapperStmt != null) {
                                             doAfterVisit(relocateBeforeMapper(mapperStmt, movableStmts));
                                         }
@@ -510,22 +513,6 @@ public class MigrateMapperSettersToBuilder extends Recipe {
 
                         return applyBuilderTemplate(mapperFqn, setterCalls, builderEntry, suffixCalls,
                                 mi.getCoordinates().replace(), ctx);
-                    }
-
-                    /**
-                     * Determine variable identifier from local declaration or field assignment
-                     * enclosing the current cursor position.
-                     */
-                    private J.@Nullable Identifier findVariableIdentifier() {
-                        J.VariableDeclarations.NamedVariable namedVar = getCursor().firstEnclosing(J.VariableDeclarations.NamedVariable.class);
-                        if (namedVar != null) {
-                            return namedVar.getName();
-                        }
-                        J.Assignment assignment = getCursor().firstEnclosing(J.Assignment.class);
-                        if (assignment != null && assignment.getVariable() instanceof J.Identifier) {
-                            return (J.Identifier) assignment.getVariable();
-                        }
-                        return null;
                     }
 
                     /**
@@ -584,7 +571,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                     if (!collecting) {
                                         break;
                                     }
-                                    J.MethodInvocation initMi = extractMethodInvocation(innerStmt);
+                                    J.MethodInvocation initMi = isSimpleExpressionStatement(innerStmt) ?
+                                            extractMethodInvocation(innerStmt) : null;
                                     if (initMi != null && isCallOnVariable(initMi, varIdent)) {
                                         if (SetterToBuilderMapping.fromSetter(initMi.getName().getSimpleName()) == null &&
                                                 !isSetterReturnType(initMi)) {
@@ -604,8 +592,11 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                 continue;
                             }
 
-                            // Check if statement is a setter call on the variable
-                            J.MethodInvocation mi = extractMethodInvocation(stmt);
+                            // Check if the statement itself is a setter call on the variable. Only
+                            // statement-level invocations qualify: digging into control flow or a
+                            // declaration initializer would hoist a conditional or consumed setter.
+                            J.MethodInvocation mi = isSimpleExpressionStatement(stmt) ?
+                                    extractMethodInvocation(stmt) : null;
                             if (mi != null && isCallOnVariable(mi, varIdent)) {
                                 if (SetterToBuilderMapping.fromSetter(mi.getName().getSimpleName()) == null &&
                                         !isSetterReturnType(mi)) {
@@ -776,6 +767,77 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         return cursor.getParentTreeCursor().getValue() instanceof J.Block;
     }
 
+    /**
+     * Walks up from the expression at {@code cursor} to the variable that directly owns it:
+     * the named variable whose declaration initializer, or the assignment whose right-hand
+     * side, is (transparently wrapped) this expression. Chained assignments with identifier
+     * targets keep walking so an enclosing declaration wins over an inner assignment —
+     * folding at the outermost owner preserves the aliasing of the single shared instance.
+     * Returns {@code null} when the expression is nested inside any other expression — e.g.
+     * an argument to another constructor, a ternary branch, or an array initializer —
+     * because the enclosing variable then does not hold the mapper, and setters called on
+     * it must not be folded.
+     */
+    private static @Nullable Cursor enclosingOwnerCursor(Cursor cursor) {
+        Cursor c = cursor.getParentTreeCursor();
+        Cursor innermostAssignment = null;
+        while (true) {
+            Object value = c.getValue();
+            if (value instanceof J.VariableDeclarations.NamedVariable) {
+                return c;
+            }
+            if (value instanceof J.Assignment) {
+                if (!(((J.Assignment) value).getVariable() instanceof J.Identifier)) {
+                    return innermostAssignment;
+                }
+                if (innermostAssignment == null) {
+                    innermostAssignment = c;
+                }
+            } else if (!isTransparentWrapper(value)) {
+                return innermostAssignment;
+            }
+            c = c.getParentTreeCursor();
+        }
+    }
+
+    private static J.Identifier ownerVariable(Cursor owner) {
+        Object value = owner.getValue();
+        if (value instanceof J.VariableDeclarations.NamedVariable) {
+            return ((J.VariableDeclarations.NamedVariable) value).getName();
+        }
+        // enclosingOwnerCursor only returns assignments with an identifier target
+        return (J.Identifier) ((J.Assignment) value).getVariable();
+    }
+
+    /**
+     * The block-level statement holding the owner, used as the anchor when relocating
+     * intermediate statements. Derived from the owner cursor itself — an unconstrained
+     * {@code firstEnclosing} could escape a lambda or anonymous-class body and anchor at
+     * an outer declaration, silently skipping the relocation.
+     */
+    private static @Nullable Statement ownerStatement(Cursor owner) {
+        if (owner.getValue() instanceof J.VariableDeclarations.NamedVariable) {
+            return owner.firstEnclosing(J.VariableDeclarations.class);
+        }
+        return (Statement) owner.getValue();
+    }
+
+    /**
+     * True for tree nodes that merely wrap their child expression without changing what
+     * instance flows to the enclosing initializer or assignment: parentheses, type casts
+     * (including Kotlin {@code as}) and the Kotlin statement/expression adapters. The
+     * Kotlin adapters are matched by class name so {@code rewrite-kotlin} stays a
+     * runtime-only dependency.
+     */
+    private static boolean isTransparentWrapper(Object tree) {
+        if (tree instanceof J.Parentheses || tree instanceof J.TypeCast) {
+            return true;
+        }
+        Class<?> c = tree.getClass();
+        return c.getName().startsWith("org.openrewrite.kotlin.") &&
+                ("ExpressionStatement".equals(c.getSimpleName()) || "StatementExpression".equals(c.getSimpleName()));
+    }
+
     private static boolean isReassignableReceiver(Expression select, Cursor cursor) {
         if (select instanceof J.Identifier) {
             return isReassignableLocal((J.Identifier) select, cursor);
@@ -836,9 +898,29 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         return null;
     }
 
+    /**
+     * The leading whitespace of the block-level statement enclosing {@code cursor},
+     * i.e. the line break and indent the statement itself starts with.
+     */
+    private static String enclosingBlockStatementWhitespace(Cursor cursor) {
+        Cursor c = cursor;
+        Cursor parent = c.getParentTreeCursor();
+        while (!(parent.getValue() instanceof J.Block) && parent.getValue() instanceof J) {
+            c = parent;
+            parent = parent.getParentTreeCursor();
+        }
+        return ((J) c.getValue()).getPrefix().getWhitespace();
+    }
+
     // Captured locals are skipped: reassigning them would break Java's effective-final requirement.
     private static @Nullable UUID reclaimableFinalLocalDeclarationId(Expression select, Cursor cursor) {
         if (!(select instanceof J.Identifier)) {
+            return null;
+        }
+        // Kotlin models `val` as a final modifier, but the keyword cannot be dropped to make
+        // the local reassignable — un-finalizing would print an invalid declaration.
+        JavaSourceFile sourceFile = cursor.firstEnclosing(JavaSourceFile.class);
+        if (sourceFile != null && sourceFile.getClass().getName().startsWith("org.openrewrite.kotlin.")) {
             return null;
         }
         J.Identifier ident = (J.Identifier) select;
@@ -966,6 +1048,13 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         J.VariableDeclarations.NamedVariable nv = vd.getVariables().get(0);
         Expression initializer = nv.getInitializer();
         if (initializer == null) {
+            return null;
+        }
+        // Only fold initializers that can act as a method-call select without parentheses;
+        // e.g. a ternary used as select would change precedence and no longer compile.
+        if (!(initializer instanceof J.MethodInvocation || initializer instanceof J.NewClass ||
+                initializer instanceof J.Identifier || initializer instanceof J.FieldAccess ||
+                initializer instanceof J.ArrayAccess || initializer instanceof J.Parentheses)) {
             return null;
         }
         RebuildParts reb = tryParseRebuildAssignment(reassignStmt);

--- a/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
+++ b/src/main/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilder.java
@@ -208,11 +208,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                             return nc;
                         }
 
-                        // Determine the owning variable, but only when this constructor call is the
-                        // variable's direct initializer / assigned value. A mapper nested inside
-                        // another expression (e.g. an argument to another constructor) does not make
-                        // the enclosing variable a mapper, so setters on it must not be folded.
-                        Cursor owner = enclosingOwnerCursor(getCursor());
+                        List<J.Identifier> aliases = new ArrayList<>();
+                        Cursor owner = enclosingOwnerCursor(getCursor(), aliases);
                         if (owner == null) {
                             return nc;
                         }
@@ -227,7 +224,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         List<Statement> movableStmts = new ArrayList<>();
                         boolean[] setterUsesIntermediate = {false};
                         List<J.MethodInvocation> builderSetters = collectStandaloneSetters(
-                                block, varIdent, new HashSet<>(), movableStmts, setterUsesIntermediate);
+                                block, varIdent, aliases, new HashSet<>(), movableStmts, setterUsesIntermediate);
 
                         if (builderSetters.isEmpty()) {
                             return nc;
@@ -246,7 +243,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
 
                         // J.NewClass implements Statement, so walk up past it to the block-level stmt.
                         if (setterUsesIntermediate[0] && !movableStmts.isEmpty()) {
-                            Statement mapperStmt = ownerStatement(owner);
+                            Statement mapperStmt = owner.getValue() instanceof J.VariableDeclarations.NamedVariable ?
+                                    owner.firstEnclosing(J.VariableDeclarations.class) : owner.getValue();
                             if (mapperStmt != null) {
                                 doAfterVisit(relocateBeforeMapper(mapperStmt, movableStmts));
                             }
@@ -326,9 +324,6 @@ public class MigrateMapperSettersToBuilder extends Recipe {
 
                         String suffix = mi.getPrefix().getWhitespace();
                         if (!suffix.contains("\n")) {
-                            // The invocation is embedded in a larger statement (e.g. an initializer);
-                            // without a line break of its own, the line comment would swallow the
-                            // rest of the line. Break at the enclosing statement's indent instead.
                             suffix = enclosingBlockStatementWhitespace(getCursor());
                         }
                         TextComment comment = new TextComment(false, commentText, suffix, Markers.EMPTY);
@@ -375,11 +370,18 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                         }
                         JavaType returnType = methodType.getReturnType();
                         if (returnType == JavaType.Primitive.Void) {
-                            // A void operational method (e.g. writeValue) must not be treated
-                            // as an unknown setter and folded into the builder.
                             return mi.getName().getSimpleName().startsWith("set");
                         }
                         return TypeUtils.isAssignableTo("com.fasterxml.jackson.databind.ObjectMapper", returnType);
+                    }
+
+                    private boolean referencesAnyVariable(Statement stmt, List<J.Identifier> varIdents) {
+                        for (J.Identifier varIdent : varIdents) {
+                            if (referencesVariable(stmt, varIdent)) {
+                                return true;
+                            }
+                        }
+                        return false;
                     }
 
                     private boolean referencesVariable(Statement stmt, J.Identifier varIdent) {
@@ -475,7 +477,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
 
                         // When the fluent chain is directly assigned to a variable, also collect
                         // standalone setter calls that follow the assignment statement
-                        Cursor owner = enclosingOwnerCursor(getCursor());
+                        List<J.Identifier> aliases = new ArrayList<>();
+                        Cursor owner = enclosingOwnerCursor(getCursor(), aliases);
                         if (owner != null) {
                             J.Identifier varIdent = ownerVariable(owner);
                             J.Block block = getCursor().firstEnclosing(J.Block.class);
@@ -483,7 +486,7 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                 List<Statement> movableStmts = new ArrayList<>();
                                 boolean[] setterUsesIntermediate = {false};
                                 List<J.MethodInvocation> standaloneSetters = collectStandaloneSetters(
-                                        block, varIdent, new HashSet<>(), movableStmts, setterUsesIntermediate);
+                                        block, varIdent, aliases, new HashSet<>(), movableStmts, setterUsesIntermediate);
                                 if (!standaloneSetters.isEmpty()) {
                                     setterCalls.addAll(standaloneSetters);
 
@@ -499,7 +502,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                     }
 
                                     if (setterUsesIntermediate[0] && !movableStmts.isEmpty()) {
-                                        Statement mapperStmt = ownerStatement(owner);
+                                        Statement mapperStmt = owner.getValue() instanceof J.VariableDeclarations.NamedVariable ?
+                                                owner.firstEnclosing(J.VariableDeclarations.class) : owner.getValue();
                                         if (mapperStmt != null) {
                                             doAfterVisit(relocateBeforeMapper(mapperStmt, movableStmts));
                                         }
@@ -527,7 +531,8 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                      * must relocate them before the mapper to keep the folded builder well-formed.
                      */
                     private List<J.MethodInvocation> collectStandaloneSetters(
-                            J.Block block, J.Identifier varIdent, Set<J.Identifier> intermediateVars,
+                            J.Block block, J.Identifier varIdent, List<J.Identifier> aliases,
+                            Set<J.Identifier> intermediateVars,
                             List<Statement> movableStmtsOut, boolean[] setterUsesIntermediateOut) {
                         List<J.MethodInvocation> setters = new ArrayList<>();
                         boolean pastDeclaration = false;
@@ -554,6 +559,11 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                         continue;
                                     }
                                 }
+                                continue;
+                            }
+
+                            if (referencesAnyVariable(stmt, aliases)) {
+                                collecting = false;
                                 continue;
                             }
 
@@ -592,9 +602,6 @@ public class MigrateMapperSettersToBuilder extends Recipe {
                                 continue;
                             }
 
-                            // Check if the statement itself is a setter call on the variable. Only
-                            // statement-level invocations qualify: digging into control flow or a
-                            // declaration initializer would hoist a conditional or consumed setter.
                             J.MethodInvocation mi = isSimpleExpressionStatement(stmt) ?
                                     extractMethodInvocation(stmt) : null;
                             if (mi != null && isCallOnVariable(mi, varIdent)) {
@@ -767,37 +774,40 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         return cursor.getParentTreeCursor().getValue() instanceof J.Block;
     }
 
-    /**
-     * Walks up from the expression at {@code cursor} to the variable that directly owns it:
-     * the named variable whose declaration initializer, or the assignment whose right-hand
-     * side, is (transparently wrapped) this expression. Chained assignments with identifier
-     * targets keep walking so an enclosing declaration wins over an inner assignment —
-     * folding at the outermost owner preserves the aliasing of the single shared instance.
-     * Returns {@code null} when the expression is nested inside any other expression — e.g.
-     * an argument to another constructor, a ternary branch, or an array initializer —
-     * because the enclosing variable then does not hold the mapper, and setters called on
-     * it must not be folded.
-     */
-    private static @Nullable Cursor enclosingOwnerCursor(Cursor cursor) {
+    private static @Nullable Cursor enclosingOwnerCursor(Cursor cursor, List<J.Identifier> aliasesOut) {
         Cursor c = cursor.getParentTreeCursor();
         Cursor innermostAssignment = null;
+        List<J.Identifier> assignmentTargets = new ArrayList<>();
         while (true) {
             Object value = c.getValue();
             if (value instanceof J.VariableDeclarations.NamedVariable) {
+                aliasesOut.addAll(assignmentTargets);
                 return c;
             }
             if (value instanceof J.Assignment) {
                 if (!(((J.Assignment) value).getVariable() instanceof J.Identifier)) {
-                    return innermostAssignment;
+                    return innermostAssignmentOwner(innermostAssignment, assignmentTargets, aliasesOut);
                 }
                 if (innermostAssignment == null) {
                     innermostAssignment = c;
                 }
+                assignmentTargets.add((J.Identifier) ((J.Assignment) value).getVariable());
             } else if (!isTransparentWrapper(value)) {
-                return innermostAssignment;
+                return innermostAssignmentOwner(innermostAssignment, assignmentTargets, aliasesOut);
             }
             c = c.getParentTreeCursor();
         }
+    }
+
+    // The innermost assignment's own target is the owner; any outer chained targets alias it.
+    private static @Nullable Cursor innermostAssignmentOwner(@Nullable Cursor innermostAssignment,
+                                                             List<J.Identifier> assignmentTargets,
+                                                             List<J.Identifier> aliasesOut) {
+        if (innermostAssignment == null) {
+            return null;
+        }
+        aliasesOut.addAll(assignmentTargets.subList(1, assignmentTargets.size()));
+        return innermostAssignment;
     }
 
     private static J.Identifier ownerVariable(Cursor owner) {
@@ -809,26 +819,6 @@ public class MigrateMapperSettersToBuilder extends Recipe {
         return (J.Identifier) ((J.Assignment) value).getVariable();
     }
 
-    /**
-     * The block-level statement holding the owner, used as the anchor when relocating
-     * intermediate statements. Derived from the owner cursor itself — an unconstrained
-     * {@code firstEnclosing} could escape a lambda or anonymous-class body and anchor at
-     * an outer declaration, silently skipping the relocation.
-     */
-    private static @Nullable Statement ownerStatement(Cursor owner) {
-        if (owner.getValue() instanceof J.VariableDeclarations.NamedVariable) {
-            return owner.firstEnclosing(J.VariableDeclarations.class);
-        }
-        return (Statement) owner.getValue();
-    }
-
-    /**
-     * True for tree nodes that merely wrap their child expression without changing what
-     * instance flows to the enclosing initializer or assignment: parentheses, type casts
-     * (including Kotlin {@code as}) and the Kotlin statement/expression adapters. The
-     * Kotlin adapters are matched by class name so {@code rewrite-kotlin} stays a
-     * runtime-only dependency.
-     */
     private static boolean isTransparentWrapper(Object tree) {
         if (tree instanceof J.Parentheses || tree instanceof J.TypeCast) {
             return true;

--- a/src/test/java/org/openrewrite/java/jackson/KotlinMigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/KotlinMigrateMapperSettersToBuilderTest.java
@@ -505,4 +505,84 @@ class KotlinMigrateMapperSettersToBuilderTest implements RewriteTest {
             );
         }
     }
+
+    @Nested
+    class NoChange {
+
+        @Issue("https://github.com/moderneinc/customer-requests/issues/2750")
+        @Test
+        void settersOnObjectConstructedWithMapperArgument() {
+            rewriteRun(
+              //language=kotlin
+              kotlin(
+                """
+                  import com.fasterxml.jackson.databind.json.JsonMapper
+
+                  class Service(mapper: JsonMapper) {
+                      fun setRetries(retries: Int) {}
+                  }
+
+                  class A {
+                      fun test() {
+                          val service = Service(JsonMapper())
+                          service.setRetries(3)
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
+
+    @Nested
+    class IfExpressionInitializer {
+
+        @Issue("https://github.com/moderneinc/customer-requests/issues/2750")
+        @Test
+        void setterAfterIfExpressionInitializerGetsTodoComment() {
+            rewriteRun(
+              //language=kotlin
+              kotlin(
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature
+                  import com.fasterxml.jackson.databind.json.JsonMapper
+
+                  class A {
+                      fun createVal(flag: Boolean, fallback: JsonMapper): JsonMapper {
+                          val mapper = if (flag) JsonMapper() else fallback
+                          mapper.enable(SerializationFeature.INDENT_OUTPUT)
+                          return mapper
+                      }
+
+                      fun createVar(flag: Boolean, fallback: JsonMapper): JsonMapper {
+                          var mapper = if (flag) JsonMapper() else fallback
+                          mapper.enable(SerializationFeature.INDENT_OUTPUT)
+                          return mapper
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.SerializationFeature
+                  import com.fasterxml.jackson.databind.json.JsonMapper
+
+                  class A {
+                      fun createVal(flag: Boolean, fallback: JsonMapper): JsonMapper {
+                          val mapper = if (flag) JsonMapper() else fallback
+                          // TODO enable could not be folded to the builder of JsonMapper. Use mapper.rebuild().enable(...).build() or move to the mapper's instantiation site.
+                          mapper.enable(SerializationFeature.INDENT_OUTPUT)
+                          return mapper
+                      }
+
+                      fun createVar(flag: Boolean, fallback: JsonMapper): JsonMapper {
+                          var mapper = if (flag) JsonMapper() else fallback
+                          // TODO enable could not be folded to the builder of JsonMapper. Use mapper.rebuild().enable(...).build() or move to the mapper's instantiation site.
+                          mapper.enable(SerializationFeature.INDENT_OUTPUT)
+                          return mapper
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
 }

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -337,6 +337,108 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
             );
         }
 
+        @Issue("https://github.com/moderneinc/customer-requests/issues/2750")
+        @Test
+        void transparentInitializerShapesStillFold() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      ObjectMapper viaCast() {
+                          ObjectMapper mapper = (ObjectMapper) new JsonMapper();
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          return mapper;
+                      }
+
+                      JsonMapper viaChainedAssignment() {
+                          JsonMapper a;
+                          JsonMapper b = a = new JsonMapper();
+                          b.enable(SerializationFeature.INDENT_OUTPUT);
+                          return a;
+                      }
+
+                      void viaArrayAccess(JsonMapper[] mappers) {
+                          JsonMapper mapper = mappers[0];
+                          mapper.disable(SerializationFeature.INDENT_OUTPUT);
+                          mappers[0] = mapper;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      ObjectMapper viaCast() {
+                          return (ObjectMapper) JsonMapper.builder()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .build();
+                      }
+
+                      JsonMapper viaChainedAssignment() {
+                          JsonMapper a;
+                          JsonMapper b = a = JsonMapper.builder()
+                                  .enable(SerializationFeature.INDENT_OUTPUT)
+                                  .build();
+                          return a;
+                      }
+
+                      void viaArrayAccess(JsonMapper[] mappers) {
+                          JsonMapper mapper = mappers[0].rebuild()
+                                  .disable(SerializationFeature.INDENT_OUTPUT)
+                                  .build();
+                          mappers[0] = mapper;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void fieldAssignedInLambdaRelocatesIntermediateStatement() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  import java.text.DateFormat;
+                  import java.text.SimpleDateFormat;
+
+                  class A {
+                      JsonMapper mapper;
+                      Runnable init = () -> {
+                          mapper = new JsonMapper();
+                          DateFormat df = new SimpleDateFormat("yyyy");
+                          mapper.setDateFormat(df);
+                      };
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  import java.text.DateFormat;
+                  import java.text.SimpleDateFormat;
+
+                  class A {
+                      JsonMapper mapper;
+                      Runnable init = () -> {
+                          DateFormat df = new SimpleDateFormat("yyyy");
+                          mapper = JsonMapper.builder()
+                                  .defaultDateFormat(df)
+                                  .build();
+                      };
+                  }
+                  """
+              )
+            );
+        }
+
         @Test
         void setDateFormatRenamedToDefaultDateFormat() {
             rewriteRun(
@@ -719,6 +821,76 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
                                   .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                                   .build();
                           return mapper;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/moderneinc/customer-requests/issues/2750")
+        @Test
+        void settersNotHoistedOutOfControlFlowOrConsumingStatements() {
+            rewriteRun(
+              java(
+                """
+                  import java.util.Locale;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper conditional(boolean production) {
+                          JsonMapper mapper = new JsonMapper();
+                          if (production) {
+                              mapper.enable(SerializationFeature.INDENT_OUTPUT);
+                          }
+                          return mapper;
+                      }
+
+                      JsonMapper ternary(boolean flag, JsonMapper fallback) {
+                          JsonMapper mapper = flag ? new JsonMapper() : fallback;
+                          mapper.enable(SerializationFeature.INDENT_OUTPUT);
+                          return mapper;
+                      }
+
+                      ObjectMapper consumed(Locale locale) {
+                          JsonMapper mapper = new JsonMapper();
+                          ObjectMapper configured = mapper.setLocale(locale);
+                          return configured;
+                      }
+                  }
+                  """,
+                """
+                  import java.util.Locale;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      JsonMapper conditional(boolean production) {
+                          JsonMapper mapper = new JsonMapper();
+                          if (production) {
+                              mapper = mapper.rebuild()
+                                      .enable(SerializationFeature.INDENT_OUTPUT)
+                                      .build();
+                          }
+                          return mapper;
+                      }
+
+                      JsonMapper ternary(boolean flag, JsonMapper fallback) {
+                          JsonMapper mapper = flag ? new JsonMapper() : fallback;
+                          mapper = mapper.rebuild()
+                                  .enable(SerializationFeature.INDENT_OUTPUT)
+                                  .build();
+                          return mapper;
+                      }
+
+                      ObjectMapper consumed(Locale locale) {
+                          JsonMapper mapper = new JsonMapper();
+                          ObjectMapper configured = // TODO setLocale could not be folded to the builder of JsonMapper. Use mapper.rebuild().defaultLocale(...).build() or move to the mapper's instantiation site.
+                          mapper.setLocale(locale);
+                          return configured;
                       }
                   }
                   """
@@ -1423,6 +1595,51 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
             );
         }
 
+        @Issue("https://github.com/moderneinc/customer-requests/issues/2750")
+        @Test
+        void fluentChainAsConstructorArgumentKeepsOuterSetters() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.Module;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Service {
+                      Service(ObjectMapper mapper) {}
+                      void setRetries(int retries) {}
+                  }
+
+                  class A {
+                      void test(Module module) {
+                          Service service = new Service(new JsonMapper().registerModule(module));
+                          service.setRetries(3);
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.Module;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class Service {
+                      Service(ObjectMapper mapper) {}
+                      void setRetries(int retries) {}
+                  }
+
+                  class A {
+                      void test(Module module) {
+                          Service service = new Service(JsonMapper.builder()
+                                  .addModule(module)
+                                  .build());
+                          service.setRetries(3);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
         @Test
         void fluentChainAssignedToVariableFollowedByMultipleSetters() {
             rewriteRun(
@@ -1751,6 +1968,41 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
             );
         }
 
+        @Test
+        void voidWriteValueNotFoldedIntoBuilder() {
+            rewriteRun(
+              java(
+                """
+                  import java.io.StringWriter;
+                  import java.text.SimpleDateFormat;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      void write(StringWriter writer, Object value) throws Exception {
+                          JsonMapper mapper = new JsonMapper();
+                          mapper.setDateFormat(new SimpleDateFormat("yyyy"));
+                          mapper.writeValue(writer, value);
+                      }
+                  }
+                  """,
+                """
+                  import java.io.StringWriter;
+                  import java.text.SimpleDateFormat;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      void write(StringWriter writer, Object value) throws Exception {
+                          JsonMapper mapper = JsonMapper.builder()
+                                  .defaultDateFormat(new SimpleDateFormat("yyyy"))
+                                  .build();
+                          mapper.writeValue(writer, value);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
         @Issue("https://github.com/openrewrite/rewrite-jackson/issues/130")
         @Test
         void writeValueAsStringNotFoldedIntoBuilder() {
@@ -1832,6 +2084,40 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
                           ObjectMapper mapper = new ObjectMapper();
                           mapper.disable(SerializationFeature.INDENT_OUTPUT);
                           return mapper;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Issue("https://github.com/moderneinc/customer-requests/issues/2750")
+        @Test
+        void settersOnObjectConstructedWithMapperArgument() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class JobCredentialListService {
+                      JobCredentialListService(JsonMapper mapper) {}
+                      void setApplicationEventPublisher(Object o) {}
+                      void setEntityManager(Object o) {}
+                      void setDateFormat(Object df) {}
+                  }
+
+                  class MyTest {
+                      JobCredentialListService service;
+
+                      void declaredLocal(Object applicationEventPublisherSpy, Object entityManagerMock) {
+                          JobCredentialListService service = new JobCredentialListService(new JsonMapper());
+                          service.setApplicationEventPublisher(applicationEventPublisherSpy);
+                          service.setEntityManager(entityManagerMock);
+                      }
+
+                      void assignedField(Object df) {
+                          service = new JobCredentialListService(new JsonMapper());
+                          service.setDateFormat(df);
                       }
                   }
                   """

--- a/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/MigrateMapperSettersToBuilderTest.java
@@ -401,6 +401,88 @@ class MigrateMapperSettersToBuilderTest implements RewriteTest {
         }
 
         @Test
+        void doNotFoldOverReferencesToChainedAssignmentAlias() {
+            rewriteRun(
+              java(
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      void use(ObjectMapper m) {}
+
+                      boolean readThroughAlias() {
+                          JsonMapper a;
+                          JsonMapper b = a = new JsonMapper();
+                          boolean before = a.isEnabled(SerializationFeature.INDENT_OUTPUT);
+                          b.enable(SerializationFeature.INDENT_OUTPUT);
+                          return before;
+                      }
+
+                      void aliasEscapesToMethod() {
+                          JsonMapper a;
+                          JsonMapper b = a = new JsonMapper();
+                          use(a);
+                          b.enable(SerializationFeature.INDENT_OUTPUT);
+                      }
+
+                      JsonMapper settersThroughBothAliases() {
+                          JsonMapper a;
+                          JsonMapper b = a = new JsonMapper();
+                          a.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                          b.enable(SerializationFeature.INDENT_OUTPUT);
+                          return b;
+                      }
+                  }
+                  """,
+                """
+                  import com.fasterxml.jackson.databind.DeserializationFeature;
+                  import com.fasterxml.jackson.databind.ObjectMapper;
+                  import com.fasterxml.jackson.databind.SerializationFeature;
+                  import com.fasterxml.jackson.databind.json.JsonMapper;
+
+                  class A {
+                      void use(ObjectMapper m) {}
+
+                      boolean readThroughAlias() {
+                          JsonMapper a;
+                          JsonMapper b = a = new JsonMapper();
+                          boolean before = a.isEnabled(SerializationFeature.INDENT_OUTPUT);
+                          b = b.rebuild()
+                                  .enable(SerializationFeature.INDENT_OUTPUT)
+                                  .build();
+                          return before;
+                      }
+
+                      void aliasEscapesToMethod() {
+                          JsonMapper a;
+                          JsonMapper b = a = new JsonMapper();
+                          use(a);
+                          b = b.rebuild()
+                                  .enable(SerializationFeature.INDENT_OUTPUT)
+                                  .build();
+                      }
+
+                      JsonMapper settersThroughBothAliases() {
+                          JsonMapper a;
+                          JsonMapper b = a = new JsonMapper();
+                          a = a.rebuild()
+                                  .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                                  .build();
+                          b = b.rebuild()
+                                  .enable(SerializationFeature.INDENT_OUTPUT)
+                                  .build();
+                          return b;
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
         void fieldAssignedInLambdaRelocatesIntermediateStatement() {
             rewriteRun(
               java(


### PR DESCRIPTION
## What's changed?

`MigrateMapperSettersToBuilder` resolved the mapper's owning variable with an unconstrained `firstEnclosing(NamedVariable/Assignment)`. The owner is now resolved by walking up from the mapper expression through value-preserving wrappers only (parentheses, casts, Kotlin statement adapters, chained identifier assignments), and the relocation anchor for intermediate statements is derived from that same walk. Guards were added on the same collection path: setters inside control flow or consumed by a declaration initializer stay put (rewritten as `rebuild()` in place or annotated with a TODO), void-returning methods only count as unknown setters when named `set*`, rebuild reassignments only fold into initializers that can act as a method-call select without parentheses, the TODO comment fallback breaks the line when embedded in a larger statement, and Kotlin `val` locals are never un-finalized.

## What's your motivation?

A `new JsonMapper()` nested inside another expression — a constructor argument, ternary branch, or array initializer — made the recipe claim the first enclosing variable as the mapper's owner and fold that variable's own setters into the builder chain, producing uncompilable output:

```java
JobCredentialListService service = new JobCredentialListService(new JsonMapper());
service.setApplicationEventPublisher(spy);   // was folded into JsonMapper.builder() with TODOs
```

It could also silently rewrite unrelated configuration (`service.setDateFormat(df)` became `.defaultDateFormat(df)` on the mapper builder), and `if (production) { mapper.enable(...); }` was hoisted unconditionally into the builder.

- Fixes https://github.com/moderneinc/customer-requests/issues/2750

## Anything in particular you'd like reviewers to focus on?

- `enclosingOwnerCursor` / `isTransparentWrapper`: the definition of "transparent" (parens, `J.TypeCast`, Kotlin `ExpressionStatement`/`StatementExpression`, chained identifier assignments) decides which owners still fold.
- The statement-level gate in `collectStandaloneSetters` (`isSimpleExpressionStatement`) narrows what qualifies as a standalone setter; conditional/consumed setters now go through the rebuild/TODO fallbacks instead.

## Any additional context

Known pre-existing gaps left out of scope (confirmed while reviewing, happy to file separately): setter collection on a shadowing same-name variable in an anonymous class body, `rebuild()` typing for user subclasses of format-aligned mappers, relocation ordering for multi-variable declarations, and TODO placement for setters in single-line blocks / Kotlin `return mapper.enable(x)` expressions.

## Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the [IntelliJ IDEA auto-formatter](https://docs.openrewrite.org/authoring-recipes/recipe-development-environment#use-the-intellij-idea-auto-formatter) on affected files