### PR TITLE
Add RemoveDeadJacksonThrows recipe to remove dead throws for unchecked Jackson exceptions

### DIFF
--- a/src/main/java/org/openrewrite/java/jackson/RemoveDeadJacksonThrows.java
+++ b/src/main/java/org/openrewrite/java/jackson/RemoveDeadJacksonThrows.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.jackson;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.NameTree;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RemoveDeadJacksonThrows extends Recipe {
+
+    private static final Set<String> TARGET_FQNS;
+    private static final Set<String> TARGET_SIMPLE_NAMES;
+
+    static {
+        Set<String> fqns = new HashSet<>(Arrays.asList(
+                // Pre-migration (com.fasterxml) namespace
+                "com.fasterxml.jackson.core.JsonProcessingException",
+                "com.fasterxml.jackson.databind.JsonMappingException",
+                // Post-migration (tools.jackson) namespace
+                "tools.jackson.core.exc.JacksonException",
+                "tools.jackson.core.exc.JsonProcessingException",
+                "tools.jackson.databind.exc.JsonMappingException",
+                "tools.jackson.databind.DatabindException"
+        ));
+        TARGET_FQNS = Collections.unmodifiableSet(fqns);
+
+        Set<String> simpleNames = new HashSet<>(Arrays.asList(
+                "JsonProcessingException",
+                "JacksonException",
+                "JsonMappingException",
+                "DatabindException"
+        ));
+        TARGET_SIMPLE_NAMES = Collections.unmodifiableSet(simpleNames);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Remove dead throws declarations for unchecked Jackson exceptions";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes `throws` declarations for Jackson exception types that are unchecked " +
+                "in Jackson 3 (`JacksonException extends RuntimeException`). " +
+                "Covers `JsonProcessingException`, `JacksonException`, `JsonMappingException`, and `DatabindException` " +
+                "in both `com.fasterxml.jackson` and `tools.jackson` namespaces.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method,
+                    ExecutionContext ctx) {
+                J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+
+                List<NameTree> throwz = m.getThrows();
+                if (throwz == null || throwz.isEmpty()) {
+                    return m;
+                }
+
+                List<NameTree> newThrowz = ListUtils.map(throwz, t -> {
+                    if (!isTargetException(t)) {
+                        return t;
+                    }
+                    JavaType type = t.getType();
+                    if (type instanceof JavaType.FullyQualified) {
+                        maybeRemoveImport(((JavaType.FullyQualified) type).getFullyQualifiedName());
+                    } else {
+                        maybeRemoveImport("com.fasterxml.jackson.core.JsonProcessingException");
+                        maybeRemoveImport("com.fasterxml.jackson.databind.JsonMappingException");
+                        maybeRemoveImport("tools.jackson.core.exc.JacksonException");
+                        maybeRemoveImport("tools.jackson.core.exc.JsonProcessingException");
+                        maybeRemoveImport("tools.jackson.databind.exc.JsonMappingException");
+                        maybeRemoveImport("tools.jackson.databind.DatabindException");
+                    }
+                    return null;
+                });
+
+                if (newThrowz == throwz) {
+                    return m;
+                }
+
+                return m.withThrows(newThrowz.isEmpty() ? null : newThrowz);
+            }
+
+            private boolean isTargetException(NameTree nameTree) {
+                JavaType type = nameTree.getType();
+                if (type instanceof JavaType.FullyQualified) {
+                    String fqn = ((JavaType.FullyQualified) type).getFullyQualifiedName();
+                    if (fqn.startsWith("<")) {
+                        return false;
+                    }
+                    return TARGET_FQNS.contains(fqn);
+                }
+                String simpleName = getSimpleName(nameTree);
+                if (!TARGET_SIMPLE_NAMES.contains(simpleName)) {
+                    return false;
+                }
+                J.CompilationUnit cu = getCursor().firstEnclosingOrThrow(J.CompilationUnit.class);
+                return cu.getImports().stream().anyMatch(imp -> {
+                    String qualifier = imp.getQualid().toString();
+                    return qualifier.toLowerCase().contains("jackson")
+                            && qualifier.endsWith("." + simpleName);
+                });
+            }
+
+            private String getSimpleName(NameTree nameTree) {
+                if (nameTree instanceof J.Identifier) {
+                    return ((J.Identifier) nameTree).getSimpleName();
+                }
+                if (nameTree instanceof J.FieldAccess) {
+                    return ((J.FieldAccess) nameTree).getSimpleName();
+                }
+                return "";
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/rewrite/jackson-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/jackson-2-3.yml
@@ -31,6 +31,7 @@ recipeList:
   - org.openrewrite.java.jackson.CodehausToFasterXML  # First, so any codehaus stragglers are on the fasterxml side
   - org.openrewrite.java.jackson.IOExceptionToJacksonException  # Before any type changes, to ensure we update catches
   - org.openrewrite.java.jackson.ReplaceIOExceptionThrowInJacksonOverrides  # Also removes `throws IOException` from the serde overrides
+  - org.openrewrite.java.jackson.RemoveDeadJacksonThrows
   - org.openrewrite.java.jackson.StdDeserializerNullConstructor
   - org.openrewrite.java.jackson.UseReadTreeAsValueInDeserializer
   - org.openrewrite.java.jackson.LombokJacksonizedConfig

--- a/src/test/java/org/openrewrite/java/jackson/RemoveDeadJacksonThrowsTest.java
+++ b/src/test/java/org/openrewrite/java/jackson/RemoveDeadJacksonThrowsTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.jackson;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+class RemoveDeadJacksonThrowsTest implements RewriteTest {
+
+    private static final String JACKSON_EXCEPTION_J3_STUB =
+            "package tools.jackson.core.exc;\n" +
+            "public class JacksonException extends RuntimeException {}\n";
+
+    private static final String JSON_PROCESSING_J3_STUB =
+            "package tools.jackson.core.exc;\n" +
+            "public class JsonProcessingException extends JacksonException {}\n";
+
+    private static final String JSON_MAPPING_J3_STUB =
+            "package tools.jackson.databind.exc;\n" +
+            "public class JsonMappingException extends tools.jackson.core.exc.JsonProcessingException {}\n";
+
+    private static final String DATABIND_EXCEPTION_J3_STUB =
+            "package tools.jackson.databind;\n" +
+            "public class DatabindException extends tools.jackson.core.exc.JacksonException {}\n";
+
+    private static final String JSON_PROCESSING_J2_STUB =
+            "package com.fasterxml.jackson.core;\n" +
+            "public class JsonProcessingException extends Exception {}\n";
+
+    private static final String JSON_MAPPING_J2_STUB =
+            "package com.fasterxml.jackson.databind;\n" +
+            "public class JsonMappingException extends com.fasterxml.jackson.core.JsonProcessingException {}\n";
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new RemoveDeadJacksonThrows())
+                .parser(JavaParser.fromJavaVersion()
+                        .dependsOn(
+                                JACKSON_EXCEPTION_J3_STUB,
+                                JSON_PROCESSING_J3_STUB,
+                                JSON_MAPPING_J3_STUB,
+                                DATABIND_EXCEPTION_J3_STUB,
+                                JSON_PROCESSING_J2_STUB,
+                                JSON_MAPPING_J2_STUB))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void removesToolsJacksonJsonProcessingException() {
+        rewriteRun(java(
+                """
+                import tools.jackson.core.exc.JsonProcessingException;
+                
+                class JsonUtil {
+                    String toJson(Object obj) throws JsonProcessingException {
+                        return obj.toString();
+                    }
+                }
+                """,
+                """
+                class JsonUtil {
+                    String toJson(Object obj) {
+                        return obj.toString();
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void removesToolsJacksonJacksonException() {
+        rewriteRun(java(
+                """
+                import tools.jackson.core.exc.JacksonException;
+                
+                class JsonUtil {
+                    String toJson(Object obj) throws JacksonException {
+                        return obj.toString();
+                    }
+                }
+                """,
+                """
+                class JsonUtil {
+                    String toJson(Object obj) {
+                        return obj.toString();
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void removesToolsJacksonJsonMappingException() {
+        rewriteRun(java(
+                """
+                import tools.jackson.databind.exc.JsonMappingException;
+                
+                class JsonUtil {
+                    String toJson(Object obj) throws JsonMappingException {
+                        return obj.toString();
+                    }
+                }
+                """,
+                """
+                class JsonUtil {
+                    String toJson(Object obj) {
+                        return obj.toString();
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void removesToolsJacksonDatabindException() {
+        rewriteRun(java(
+                """
+                import tools.jackson.databind.DatabindException;
+                
+                class JsonUtil {
+                    String toJson(Object obj) throws DatabindException {
+                        return obj.toString();
+                    }
+                }
+                """,
+                """
+                class JsonUtil {
+                    String toJson(Object obj) {
+                        return obj.toString();
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void removesFasterxmlJsonProcessingException() {
+        rewriteRun(java(
+                """
+                import com.fasterxml.jackson.core.JsonProcessingException;
+                
+                class JsonUtil {
+                    String toJson(Object obj) throws JsonProcessingException {
+                        return obj.toString();
+                    }
+                }
+                """,
+                """
+                class JsonUtil {
+                    String toJson(Object obj) {
+                        return obj.toString();
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void removesFasterxmlJsonMappingException() {
+        rewriteRun(java(
+                """
+                import com.fasterxml.jackson.databind.JsonMappingException;
+                
+                class JsonUtil {
+                    void parse(String json) throws JsonMappingException {
+                    }
+                }
+                """,
+                """
+                class JsonUtil {
+                    void parse(String json) {
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void removesJacksonExceptionLeavingIoException() {
+        rewriteRun(java(
+                """
+                import tools.jackson.core.exc.JsonProcessingException;
+                import java.io.IOException;
+                
+                class JsonUtil {
+                    void writeToFile(Object obj) throws IOException, JsonProcessingException {
+                    }
+                }
+                """,
+                """
+                import java.io.IOException;
+                
+                class JsonUtil {
+                    void writeToFile(Object obj) throws IOException {
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void removesMultipleJacksonExceptions() {
+        rewriteRun(java(
+                """
+                import tools.jackson.core.exc.JacksonException;
+                import tools.jackson.core.exc.JsonProcessingException;
+                
+                class JsonUtil {
+                    void process() throws JacksonException, JsonProcessingException {
+                    }
+                }
+                """,
+                """
+                class JsonUtil {
+                    void process() {
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void noOpWhenNoThrowsClause() {
+        rewriteRun(java(
+                """
+                class JsonUtil {
+                    String toJson(Object obj) {
+                        return obj.toString();
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void noOpWhenOnlyIoException() {
+        rewriteRun(java(
+                """
+                import java.io.IOException;
+                
+                class JsonUtil {
+                    void writeToFile() throws IOException {
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void noOpWhenOnlyRuntimeException() {
+        rewriteRun(java(
+                """
+                class JsonUtil {
+                    void compute() throws RuntimeException {
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void removesJacksonExceptionFromConstructorThrows() {
+        rewriteRun(java(
+                """
+                import tools.jackson.core.exc.JsonProcessingException;
+                
+                class JsonFactory {
+                    JsonFactory() throws JsonProcessingException {
+                    }
+                }
+                """,
+                """
+                class JsonFactory {
+                    JsonFactory() {
+                    }
+                }
+                """
+        ));
+    }
+
+    @Test
+    void removesJacksonExceptionFromInterfaceMethodThrows() {
+        rewriteRun(java(
+                """
+                import tools.jackson.core.exc.JsonProcessingException;
+                
+                interface JsonProcessor {
+                    String process(byte[] data) throws JsonProcessingException;
+                }
+                """,
+                """
+                interface JsonProcessor {
+                    String process(byte[] data);
+                }
+                """
+        ));
+    }
+
+    @Test
+    void removesJacksonThrowsFromMultipleMethodsInSameClass() {
+        rewriteRun(java(
+                """
+                import tools.jackson.core.exc.JsonProcessingException;
+                import tools.jackson.core.exc.JacksonException;
+                import java.io.IOException;
+                
+                class JsonService {
+                    void serializeAll() throws JsonProcessingException, JacksonException {
+                    }
+                    void readFile() throws IOException, JsonProcessingException {
+                    }
+                    void compute() throws RuntimeException {
+                    }
+                    void plain() {
+                    }
+                }
+                """,
+                """
+                import java.io.IOException;
+                
+                class JsonService {
+                    void serializeAll() {
+                    }
+                    void readFile() throws IOException {
+                    }
+                    void compute() throws RuntimeException {
+                    }
+                    void plain() {
+                    }
+                }
+                """
+        ));
+    }
+}


### PR DESCRIPTION
- Closes #161

## Summary

Adds a new `RemoveDeadJacksonThrows` recipe that removes dead `throws` declarations for Jackson exception types that became unchecked in Jackson 3, and wires it into `jackson-2-3.yml` immediately after `ReplaceIOExceptionThrowInJacksonOverrides`.

---

## Root Cause

In Jackson 2, `JsonProcessingException` extended `IOException`, making it a **checked** exception. Methods calling Jackson APIs were required (or encouraged) to declare:

```java
public String serialize(Object obj) throws JsonProcessingException { ... }
```

In Jackson 3, the entire Jackson exception hierarchy was rerooted under `JacksonException`, which now extends `RuntimeException`. Every Jackson exception is therefore **unchecked**. Remaining `throws` declarations for these types are syntactically valid Java but semantically dead — callers are not required to handle or propagate them, and the declarations mislead consumers into thinking checked exception handling is needed when it is not.

---

## Gap This Recipe Fills

Two existing recipes in the pipeline handle adjacent problems but neither removes dead throws from general application methods:

| Recipe | What it does | What it does NOT do |
|--------|-------------|---------------------|
| `IOExceptionToJacksonException` | Renames `IOException` → `JacksonException` in catches and throws | Does not remove throws — only renames them |
| `ReplaceIOExceptionThrowInJacksonOverrides` | Removes `throws IOException` from `serialize()`/`deserialize()` override signatures | Scoped strictly to Jackson serializer/deserializer override methods |

Neither recipe removes dead throws from **general application methods and constructors** (e.g. a service method, a utility class, a constructor). This recipe fills that gap.

---

## What This Recipe Does

Removes `throws` declarations for the following exception types from any method or constructor in which they appear:

**Pre-migration (`com.fasterxml.jackson`) namespace:**

- `com.fasterxml.jackson.core.JsonProcessingException`
- `com.fasterxml.jackson.databind.JsonMappingException`

**Post-migration (`tools.jackson`) namespace:**

- `tools.jackson.core.exc.JacksonException`
- `tools.jackson.core.exc.JsonProcessingException`
- `tools.jackson.databind.exc.JsonMappingException`
- `tools.jackson.databind.DatabindException`

Cleans up now-unused imports automatically.

### Before → After

**Before:**

```java
import com.fasterxml.jackson.core.JsonProcessingException;

public String serialize(Object obj) throws JsonProcessingException {
    return mapper.writeValueAsString(obj);
}

public void parse(String json) throws JsonProcessingException, IOException {
}
```

**After:**

```java
import java.io.IOException;

public String serialize(Object obj) {
    return mapper.writeValueAsString(obj);
}

public void parse(String json) throws IOException {
}
```

### What This Recipe Does NOT Touch

- `throws IOException` — still a **checked** exception in Java and unrelated to Jackson 3's unchecked transition. Removing it would silently break the method's contract.
- `throws RuntimeException` and other non-Jackson exception types — out of scope entirely; this recipe is scoped only to Jackson exception types.
- `catch (JacksonException e)` blocks — catch blocks represent real developer-written logic to handle Jackson errors. Unchecked exceptions can still be caught intentionally. Removing them would break the code.
- Method bodies — this recipe operates only on method signatures (the `throws` clause). Bodies are never touched.

---

## Design Decisions

### Dual-Namespace Handling

The recipe targets both `com.fasterxml.jackson` (pre-migration) and `tools.jackson` (post-migration) namespaces. This is intentional: the recipe runs after `UpgradeJackson_2_3` in the pipeline, but type resolution can partially fail mid-migration — some files may not have their imports renamed yet when this recipe executes. Targeting both namespaces ensures correct behaviour regardless of which migration state a given file is in. It also makes the recipe safe to run standalone, outside the full pipeline.

### Import Guard on Simple-Name Fallback

When type resolution fails completely (type is unresolved), the recipe falls back to simple-name matching (`JsonProcessingException`, `JacksonException`, etc.). However, it only fires this fallback when a Jackson-namespace import is present in the compilation unit. This prevents false-positive removal on user-defined exception types that happen to share a simple name with Jackson exception types.

### `DatabindException` Included

`DatabindException` (`tools.jackson.databind.DatabindException`) is the Jackson 3 replacement for `JsonMappingException` at the databind layer and is included as a target alongside the others.

### Pipeline Position

The recipe is inserted immediately after `ReplaceIOExceptionThrowInJacksonOverrides` so that IOException-related cleanup on override method signatures is already applied before this recipe handles the broader general-method case:

```yaml
- org.openrewrite.java.jackson.IOExceptionToJacksonException
- org.openrewrite.java.jackson.ReplaceIOExceptionThrowInJacksonOverrides
- org.openrewrite.java.jackson.RemoveDeadJacksonThrows   # ← this PR
- org.openrewrite.java.jackson.StdDeserializerNullConstructor
```

---

## Test Coverage

`RemoveDeadJacksonThrowsTest` — 14 test cases:

### Positive (throws removed)

- `tools.jackson` `JsonProcessingException` on a general method
- `tools.jackson` `JacksonException` on a general method
- `tools.jackson` `JsonMappingException` on a general method
- `tools.jackson` `DatabindException` on a general method
- `com.fasterxml.jackson` `JsonProcessingException` on a general method
- `com.fasterxml.jackson` `JsonMappingException` on a general method
- Mixed throws — Jackson exception removed, `IOException` preserved
- Multiple Jackson exception types on the same method — all removed
- Jackson exception on a constructor
- Jackson exception on an interface method

### Negative (no change)

- Method with no throws clause
- Method with only `throws IOException`
- Method with only `throws RuntimeException`

### Multi-Method

- Class with multiple methods — each handled independently, only Jackson throws removed, `IOException` and `RuntimeException` left untouched across all methods

---

## Build

No changes to `build.gradle.kts` — both Jackson 2 (`com.fasterxml.jackson.core:jackson-databind:2.19.2`) and Jackson 3 (`tools.jackson.core:jackson-databind:3.+`) are already on the `testParserClasspath`, so all dual-namespace test cases resolve correctly without any dependency additions.

---

## Validation

```
./gradlew test

BUILD SUCCESSFUL in 25m 1s
5 actionable tasks: 5 executed
```

Full upstream test suite passed with zero failures alongside the new recipe's tests.